### PR TITLE
bfs/exec.c: fix failure with large 64k ppc64le page size

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -95,6 +95,10 @@ static size_t bfs_exec_arg_max(const struct bfs_exec *execbuf) {
 	long page_size = sysconf(_SC_PAGESIZE);
 	if (page_size < 4096) {
 		page_size = 4096;
+	} else {
+		if (page_size > (BFS_EXEC_ARG_MAX/1024)) {
+			page_size = BFS_EXEC_ARG_MAX/1024;
+		}
 	}
 	arg_max -= 2*page_size;
 	bfs_exec_debug(execbuf, "ARG_MAX: %ld remaining after headroom\n", arg_max);


### PR DESCRIPTION
test_exec_plus test fails because  bfs_exec_arg_max() call to sysconf(_SC_ARG_MAX) is not large enough to contain two 64K pages (ppc64le default page size). Since maximum argument size allowed by BFS is only 16K anyway (BFS_EXEC_ARG_MAX) then update arg size check to make sure it is at least 32k. Note that this is occurring on Alpine Linux edge build.