### PR TITLE
RFC - DO NOT MERGE. Add some sort options.

### DIFF
--- a/bftw.h
+++ b/bftw.h
@@ -167,6 +167,10 @@ enum bftw_flags {
 	BFTW_PRUNE_MOUNTS  = 1 << 7,
 	/** Sort directory entries before processing them. */
 	BFTW_SORT          = 1 << 8,
+	/** Sort flags when using BFTW_SORT. */
+	BFTW_SORT_STRCMP   = 1 << 9, // sort using strcmp() instead of strcoll()
+	BFTW_SORT_DIRS_FIRST = 1 << 10, // directories sort first
+	BFTW_SORT_DIRS_LAST = 1 << 11, // directories sort last
 };
 
 /**

--- a/parse.c
+++ b/parse.c
@@ -2163,7 +2163,8 @@ list_types:
  * Parse -s.
  */
 static struct expr *parse_s(struct parser_state *state, int arg1, int arg2) {
-	state->ctx->flags |= BFTW_SORT;
+	state->ctx->flags &= ~arg2;  // clear bits
+	state->ctx->flags |= BFTW_SORT | arg1; // and set bits
 	return parse_nullary_flag(state);
 }
 
@@ -2985,7 +2986,12 @@ static const struct table_entry parse_table[] = {
 	{"-regex", T_TEST, parse_regex, 0},
 	{"-regextype", T_OPTION, parse_regextype},
 	{"-rm", T_ACTION, parse_delete},
-	{"-s", T_FLAG, parse_s},
+	{"-s", T_FLAG, parse_s, 0, 0}, // defaults to strcoll()
+	{"-sort-strcmp", T_FLAG, parse_s, BFTW_SORT_STRCMP, 0}, // force strcmp()
+	{"-sort-strcoll", T_FLAG, parse_s, 0, BFTW_SORT_STRCMP}, // force strcoll()
+	{"-sort-df", T_FLAG, parse_s, BFTW_SORT_DIRS_FIRST, BFTW_SORT_DIRS_LAST},
+	{"-sort-dl", T_FLAG, parse_s, BFTW_SORT_DIRS_LAST, BFTW_SORT_DIRS_FIRST},
+	{"-sort-dn", T_FLAG, parse_s, 0, BFTW_SORT_DIRS_FIRST|BFTW_SORT_DIRS_LAST}, // DIRS_NONE, i.e. reset to default
 	{"-samefile", T_TEST, parse_samefile},
 	{"-since", T_TEST, parse_since, BFS_STAT_MTIME},
 	{"-size", T_TEST, parse_size},


### PR DESCRIPTION
This commit is meant to help examining path traversal and print order,
and to allow playing around with the flags listed below.

Unfortunately the docs are pretty scarce on this topic.

GOAL: find out how these flags interact with each other, and
add some nice test-cases that also serve as documentation

bfs offers some strategy flags:
  -S bfs  breadth-first - default
  -S dfs  depth-first - like find(1)
  -S ids  ???
  -S eds  ???

bfs offers some depth flags:
  -d       POST_ORDER => how does this interact with strategy ?

bfs offers some sort flags:
  -s             sort entries by name (using strcoll)
  -sort-strcmp   NEW: this is useful when you cannot use LC_ALL=C
  -sort-df       NEW: sort directory entries first
  -sort-dl       NEW: sort directory entries last