### PR TITLE
Async I/O queue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,7 @@ LIBBFS := \
     $(OBJ)/src/eval.o \
     $(OBJ)/src/exec.o \
     $(OBJ)/src/fsade.o \
+    $(OBJ)/src/ioq.o \
     $(OBJ)/src/mtab.o \
     $(OBJ)/src/opt.o \
     $(OBJ)/src/parse.o \

--- a/docs/bfs.1
+++ b/docs/bfs.1
@@ -171,12 +171,18 @@ consumes too much memory.
 .TP
 .I eds
 Exponential deepening search.
-A compromise between breadth- and depth-first search, which searches exponentially increasing depth ranges (e.g 0-1, 1-2, 2-4, 4-8, etc.).
+A compromise between breadth- and depth-first search, which searches exponentially increasing depth ranges (e.g. 0-1, 1-2, 2-4, 4-8, etc.).
 Provides many of the benefits of breadth-first search with depth-first's reduced memory consumption.
 Typically far faster than
 .B \-S
 .IR ids .
 .RE
+.TP
+\fB\-j\fIN\fR
+Search with
+.I N
+threads in parallel (default: number of CPUs, up to
+.IR 8 ).
 .SH OPERATORS
 .TP
 \fB( \fIexpression \fB)\fR

--- a/src/bftw.c
+++ b/src/bftw.c
@@ -853,13 +853,13 @@ static int bftw_gc(struct bftw_state *state, enum bftw_gc_flags flags) {
 
 		if (file->refcount > 1) {
 			// Keep the fd around if any subdirectories exist
-			file->fd = bfs_freedir(state->dir);
+			file->fd = bfs_freedir(state->dir, false);
 		} else {
-			bfs_closedir(state->dir);
 			file->fd = -1;
 		}
 
 		if (file->fd < 0) {
+			bfs_closedir(state->dir);
 			bftw_cache_remove(&state->cache, file);
 		}
 	}

--- a/src/bftw.h
+++ b/src/bftw.h
@@ -186,6 +186,8 @@ struct bftw_args {
 	void *ptr;
 	/** The maximum number of file descriptors to keep open. */
 	int nopenfd;
+	/** The maximum number of threads to use. */
+	int nthreads;
 	/** Flags that control bftw() behaviour. */
 	enum bftw_flags flags;
 	/** The search strategy to use. */

--- a/src/ctx.c
+++ b/src/ctx.c
@@ -56,6 +56,7 @@ struct bfs_ctx *bfs_ctx_new(void) {
 	ctx->maxdepth = INT_MAX;
 	ctx->flags = BFTW_RECOVER;
 	ctx->strategy = BFTW_BFS;
+	ctx->threads = 0;
 	ctx->optlevel = 3;
 	ctx->debug = 0;
 	ctx->ignore_races = false;

--- a/src/ctx.h
+++ b/src/ctx.h
@@ -68,6 +68,8 @@ struct bfs_ctx {
 	/** bftw() search strategy. */
 	enum bftw_strategy strategy;
 
+	/** Threads (-j). */
+	int threads;
 	/** Optimization level (-O). */
 	int optlevel;
 	/** Debugging flags (-D). */

--- a/src/dir.h
+++ b/src/dir.h
@@ -80,6 +80,16 @@ struct bfs_dir *bfs_opendir(int at_fd, const char *at_path);
 int bfs_dirfd(const struct bfs_dir *dir);
 
 /**
+ * Performs any I/O necessary for the next bfs_readdir() call.
+ *
+ * @param dir
+ *         The directory to poll.
+ * @return
+ *         1 on success, 0 on EOF, or -1 on failure.
+ */
+int bfs_polldir(struct bfs_dir *dir);
+
+/**
  * Read a directory entry.
  *
  * @param dir

--- a/src/dir.h
+++ b/src/dir.h
@@ -8,6 +8,7 @@
 #ifndef BFS_DIR_H
 #define BFS_DIR_H
 
+#include "config.h"
 #include <sys/types.h>
 
 /**
@@ -103,9 +104,14 @@ int bfs_closedir(struct bfs_dir *dir);
  *
  * @param dir
  *         The directory to free.
+ * @param same_fd
+ *         If true, require that the returned file descriptor is the same one
+ *         that bfs_dirfd() would have returned.  Otherwise, it may be a new
+ *         file descriptor for the same directory.
  * @return
- *         The file descriptor on success, or -1 on failure.
+ *         On success, a file descriptor for the directory is returned.  On
+ *         failure, -1 is returned, and the directory remains open.
  */
-int bfs_freedir(struct bfs_dir *dir);
+int bfs_freedir(struct bfs_dir *dir, bool same_fd);
 
 #endif // BFS_DIR_H

--- a/src/ioq.c
+++ b/src/ioq.c
@@ -158,6 +158,10 @@ static void *ioq_work(void *ptr) {
 		res->ptr = req.ptr;
 		res->dir = bfs_opendir(req.dfd, req.path);
 		res->error = errno;
+		if (res->dir) {
+			bfs_polldir(res->dir);
+		}
+
 		ioqq_push(ioq->ready, cmd);
 	}
 

--- a/src/ioq.c
+++ b/src/ioq.c
@@ -155,6 +155,7 @@ static void *ioq_work(void *ptr) {
 		sanitize_uninit(cmd);
 
 		struct ioq_res *res = &cmd->res;
+		res->ptr = req.ptr;
 		res->dir = bfs_opendir(req.dfd, req.path);
 		res->error = errno;
 		ioqq_push(ioq->ready, cmd);

--- a/src/ioq.c
+++ b/src/ioq.c
@@ -1,0 +1,284 @@
+// Copyright © Tavian Barnes <tavianator@tavianator.com>
+// SPDX-License-Identifier: 0BSD
+
+#include "ioq.h"
+#include "dir.h"
+#include "list.h"
+#include "lock.h"
+#include "sanity.h"
+#include <assert.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+/**
+ * An I/O queue request.
+ */
+struct ioq_req {
+	/** Base file descriptor for openat(). */
+	int dfd;
+	/** Relative path to dfd. */
+	const char *path;
+
+	/** Arbitrary user data. */
+	void *ptr;
+};
+
+/**
+ * An I/O queue command.
+ */
+struct ioq_cmd {
+	union {
+		struct ioq_req req;
+		struct ioq_res res;
+	};
+
+	struct ioq_cmd *next;
+};
+
+/**
+ * An MPMC queue of I/O commands.
+ */
+struct ioqq {
+	pthread_mutex_t mutex;
+	pthread_cond_t cond;
+
+	bool stop;
+
+	struct ioq_cmd *head;
+	struct ioq_cmd **tail;
+};
+
+static struct ioqq *ioqq_create(void) {
+	struct ioqq *ioqq = malloc(sizeof(*ioqq));
+	if (!ioqq) {
+		goto fail;
+	}
+
+	if (mutex_init(&ioqq->mutex, NULL) != 0) {
+		goto fail_free;
+	}
+
+	if (cond_init(&ioqq->cond, NULL) != 0) {
+		goto fail_mutex;
+	}
+
+	ioqq->stop = false;
+	SLIST_INIT(ioqq);
+	return ioqq;
+
+fail_mutex:
+	mutex_destroy(&ioqq->mutex);
+fail_free:
+	free(ioqq);
+fail:
+	return NULL;
+}
+
+/** Push a command onto the queue. */
+static void ioqq_push(struct ioqq *ioqq, struct ioq_cmd *cmd) {
+	mutex_lock(&ioqq->mutex);
+	SLIST_APPEND(ioqq, cmd);
+	mutex_unlock(&ioqq->mutex);
+	cond_signal(&ioqq->cond);
+}
+
+/** Pop a command from a queue. */
+static struct ioq_cmd *ioqq_pop(struct ioqq *ioqq) {
+	mutex_lock(&ioqq->mutex);
+
+	while (!ioqq->stop && !ioqq->head) {
+		cond_wait(&ioqq->cond, &ioqq->mutex);
+	}
+
+	struct ioq_cmd *cmd = SLIST_POP(ioqq);
+	mutex_unlock(&ioqq->mutex);
+	return cmd;
+}
+
+/** Pop a command from a queue without blocking. */
+static struct ioq_cmd *ioqq_trypop(struct ioqq *ioqq) {
+	if (!mutex_trylock(&ioqq->mutex)) {
+		return NULL;
+	}
+
+	struct ioq_cmd *cmd = SLIST_POP(ioqq);
+	mutex_unlock(&ioqq->mutex);
+	return cmd;
+}
+
+/** Stop a queue, waking up any waiters. */
+static void ioqq_stop(struct ioqq *ioqq) {
+	mutex_lock(&ioqq->mutex);
+	ioqq->stop = true;
+	mutex_unlock(&ioqq->mutex);
+	cond_broadcast(&ioqq->cond);
+}
+
+static void ioqq_destroy(struct ioqq *ioqq) {
+	if (ioqq) {
+		cond_destroy(&ioqq->cond);
+		mutex_destroy(&ioqq->mutex);
+		free(ioqq);
+	}
+}
+
+struct ioq {
+	/** The depth of the queue. */
+	size_t depth;
+	/** The current size of the queue. */
+	size_t size;
+
+	/** Pending I/O requests. */
+	struct ioqq *pending;
+	/** Ready I/O responses. */
+	struct ioqq *ready;
+
+	/** The number of background threads. */
+	size_t nthreads;
+	/** The background threads themselves. */
+	pthread_t *threads;
+};
+
+/** Background thread entry point. */
+static void *ioq_work(void *ptr) {
+	struct ioq *ioq = ptr;
+
+	while (true) {
+		struct ioq_cmd *cmd = ioqq_pop(ioq->pending);
+		if (!cmd) {
+			break;
+		}
+
+		struct ioq_req req = cmd->req;
+		sanitize_uninit(cmd);
+
+		struct ioq_res *res = &cmd->res;
+		res->dir = bfs_opendir(req.dfd, req.path);
+		res->error = errno;
+		ioqq_push(ioq->ready, cmd);
+	}
+
+	return NULL;
+}
+
+struct ioq *ioq_create(size_t depth, size_t threads) {
+	struct ioq *ioq = malloc(sizeof(*ioq));
+	if (!ioq) {
+		goto fail;
+	}
+
+	ioq->depth = depth;
+	ioq->size = 0;
+	ioq->pending = NULL;
+	ioq->ready = NULL;
+	ioq->nthreads = 0;
+
+	ioq->pending = ioqq_create();
+	if (!ioq->pending) {
+		goto fail;
+	}
+
+	ioq->ready = ioqq_create();
+	if (!ioq->ready) {
+		goto fail;
+	}
+
+	ioq->threads = malloc(threads * sizeof(ioq->threads[0]));
+	if (!ioq->threads) {
+		goto fail;
+	}
+
+	for (size_t i = 0; i < threads; ++i) {
+		errno = pthread_create(&ioq->threads[i], NULL, ioq_work, ioq);
+		if (errno != 0) {
+			goto fail;
+		}
+		++ioq->nthreads;
+	}
+
+	return ioq;
+
+	int err;
+fail:
+	err = errno;
+	ioq_destroy(ioq);
+	errno = err;
+	return NULL;
+}
+
+int ioq_opendir(struct ioq *ioq, int dfd, const char *path, void *ptr) {
+	if (ioq->size >= ioq->depth) {
+		return -1;
+	}
+
+	struct ioq_cmd *cmd = malloc(sizeof(*cmd));
+	if (!cmd) {
+		return -1;
+	}
+
+	struct ioq_req *req = &cmd->req;
+	req->dfd = dfd;
+	req->path = path;
+	req->ptr = ptr;
+
+	++ioq->size;
+	ioqq_push(ioq->pending, cmd);
+	return 0;
+}
+
+struct ioq_res *ioq_pop(struct ioq *ioq) {
+	if (ioq->size == 0) {
+		return NULL;
+	}
+
+	struct ioq_cmd *cmd = ioqq_pop(ioq->ready);
+	if (!cmd) {
+		return NULL;
+	}
+
+	--ioq->size;
+	return &cmd->res;
+}
+
+struct ioq_res *ioq_trypop(struct ioq *ioq) {
+	if (ioq->size == 0) {
+		return NULL;
+	}
+
+	struct ioq_cmd *cmd = ioqq_trypop(ioq->ready);
+	if (!cmd) {
+		return NULL;
+	}
+
+	--ioq->size;
+	return &cmd->res;
+}
+
+void ioq_free(struct ioq *ioq, struct ioq_res *res) {
+	struct ioq_cmd *cmd = (struct ioq_cmd *)res;
+	free(cmd);
+}
+
+void ioq_destroy(struct ioq *ioq) {
+	if (!ioq) {
+		return;
+	}
+
+	if (ioq->pending) {
+		ioqq_stop(ioq->pending);
+	}
+
+	for (size_t i = 0; i < ioq->nthreads; ++i) {
+		if (pthread_join(ioq->threads[i], NULL) != 0) {
+			abort();
+		}
+	}
+	free(ioq->threads);
+
+	ioqq_destroy(ioq->ready);
+	ioqq_destroy(ioq->pending);
+
+	free(ioq);
+}

--- a/src/ioq.h
+++ b/src/ioq.h
@@ -1,0 +1,94 @@
+// Copyright © Tavian Barnes <tavianator@tavianator.com>
+// SPDX-License-Identifier: 0BSD
+
+/**
+ * Asynchronous I/O queues.
+ */
+
+#ifndef BFS_IOQ_H
+#define BFS_IOQ_H
+
+#include <stddef.h>
+
+/**
+ * An queue of asynchronous I/O operations.
+ */
+struct ioq;
+
+/**
+ * An I/O queue response.
+ */
+struct ioq_res {
+	/** The opened directory. */
+	struct bfs_dir *dir;
+	/** The error code, if the operation failed. */
+	int error;
+
+	/** Arbitrary user data. */
+	void *ptr;
+};
+
+/**
+ * Create an I/O queue.
+ *
+ * @param depth
+ *         The maximum depth of the queue.
+ * @param threads
+ *         The maximum number of background threads.
+ * @return
+ *         The new I/O queue, or NULL on failure.
+ */
+struct ioq *ioq_create(size_t depth, size_t threads);
+
+/**
+ * Asynchronous bfs_opendir().
+ *
+ * @param ioq
+ *         The I/O queue.
+ * @param dfd
+ *         The base file descriptor.
+ * @param path
+ *         The path to open, relative to dfd.
+ * @param ptr
+ *         An arbitrary pointer to associate with the request.
+ * @return
+ *         0 on success, or -1 on failure.
+ */
+int ioq_opendir(struct ioq *ioq, int dfd, const char *path, void *ptr);
+
+/**
+ * Pop a response from the queue.
+ *
+ * @param ioq
+ *         The I/O queue.
+ * @return
+ *         The next response, or NULL.
+ */
+struct ioq_res *ioq_pop(struct ioq *ioq);
+
+/**
+ * Pop a response from the queue, without blocking.
+ *
+ * @param ioq
+ *         The I/O queue.
+ * @return
+ *         The next response, or NULL.
+ */
+struct ioq_res *ioq_trypop(struct ioq *ioq);
+
+/**
+ * Free a response.
+ *
+ * @param ioq
+ *         The I/O queue.
+ * @param res
+ *         The response to free.
+ */
+void ioq_free(struct ioq *ioq, struct ioq_res *res);
+
+/**
+ * Stop and destroy an I/O queue.
+ */
+void ioq_destroy(struct ioq *ioq);
+
+#endif // BFS_IOQ_H

--- a/src/main.c
+++ b/src/main.c
@@ -31,6 +31,7 @@
  *     - dir.[ch]      (a directory API facade)
  *     - dstring.[ch]  (a dynamic string library)
  *     - fsade.[ch]    (a facade over non-standard filesystem features)
+ *     - ioq.[ch]      (an async I/O queue)
  *     - list.h        (linked list macros)
  *     - lock.h        (mutexes, condition variables, etc.)
  *     - mtab.[ch]     (parses the system's mount table)


### PR DESCRIPTION
See #101.

# Performance

Performance is a work-in-progress; not every optimization from #101 is implemented yet.  Here's a quick summary of the results so far:

- https://github.com/tavianator/bfs/pull/100/commits/9dca9f2bcd06f921312762e0b07254f5f8f51fc2 (eval: Pre-allocate the highest fd) saves *hundreds of ms* in some cases
- Complete traversal is already ~40% faster on large trees
- Early termination can be quite a bit faster (3-11x), though with higher variance
- Cold cache searches are also much faster (~40%)
- ~~Depth-first search is quite a bit slower (3.8x)~~
  - Fixed: it helps to actually do any parallelism at all in depth-first mode ;)

<details>
<summary>Full benchmark results</summary>

## Complete traversal

### Small tree

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/bfs/history -false` | 4.2 ± 2.5 | 1.5 | 9.0 | 2.45 ± 2.38 |
| `bfs-ioq~2 ~/code/bfs/history -false` | 63.7 ± 11.6 | 36.7 | 95.2 | 37.44 ± 29.75 |
| `bfs-ioq~1 ~/code/bfs/history -false` | 5.0 ± 2.6 | 2.6 | 12.3 | 2.96 ± 2.74 |
| `bfs-ioq ~/code/bfs/history -false` | 1.7 ± 1.3 | 0.7 | 8.2 | 1.00 |

### Medium tree

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/linux -false` | 65.9 ± 10.0 | 57.5 | 102.2 | 1.17 ± 0.27 |
| `bfs-ioq~2 ~/code/linux -false` | 248.3 ± 44.1 | 190.2 | 318.8 | 4.40 ± 1.10 |
| `bfs-ioq~1 ~/code/linux -false` | 86.1 ± 12.5 | 70.9 | 113.3 | 1.53 ± 0.35 |
| `bfs-ioq ~/code/linux -false` | 56.4 ± 9.9 | 44.3 | 74.9 | 1.00 |

### Large tree

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/android -false` | 1.128 ± 0.032 | 1.091 | 1.192 | 1.42 ± 0.08 |
| `bfs-ioq~2 ~/code/android -false` | 1.563 ± 0.070 | 1.444 | 1.680 | 1.97 ± 0.12 |
| `bfs-ioq~1 ~/code/android -false` | 1.350 ± 0.055 | 1.283 | 1.433 | 1.70 ± 0.10 |
| `bfs-ioq ~/code/android -false` | 0.792 ± 0.035 | 0.739 | 0.851 | 1.00 |


## Early termination

### Shallow file

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/android -name ConstClassBenchmark.java -quit` | 129.6 ± 11.6 | 120.7 | 156.2 | 1.00 |
| `bfs-ioq~2 ~/code/android -name ConstClassBenchmark.java -quit` | 694.8 ± 586.9 | 179.3 | 1711.8 | 5.36 ± 4.55 |
| `bfs-ioq~1 ~/code/android -name ConstClassBenchmark.java -quit` | 364.9 ± 257.8 | 27.9 | 694.6 | 2.82 ± 2.01 |
| `bfs-ioq ~/code/android -name ConstClassBenchmark.java -quit` | 135.0 ± 162.7 | 14.8 | 802.8 | 1.04 ± 1.26 |

### Medium file

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/android -name DominatorsComputation.java -quit` | 1.098 ± 0.023 | 1.073 | 1.141 | 11.41 ± 18.21 |
| `bfs-ioq~2 ~/code/android -name DominatorsComputation.java -quit` | 0.435 ± 0.324 | 0.259 | 1.276 | 4.52 ± 7.97 |
| `bfs-ioq~1 ~/code/android -name DominatorsComputation.java -quit` | 0.469 ± 0.482 | 0.080 | 1.067 | 4.87 ± 9.24 |
| `bfs-ioq ~/code/android -name DominatorsComputation.java -quit` | 0.096 ± 0.154 | 0.042 | 0.942 | 1.00 |

### Deep file

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/android -name TestSidecarCompat.java -quit` | 1.351 ± 0.023 | 1.314 | 1.392 | 3.07 ± 1.98 |
| `bfs-ioq~2 ~/code/android -name TestSidecarCompat.java -quit` | 0.886 ± 0.562 | 0.262 | 1.587 | 2.01 ± 1.82 |
| `bfs-ioq~1 ~/code/android -name TestSidecarCompat.java -quit` | 0.501 ± 0.412 | 0.093 | 1.403 | 1.14 ± 1.19 |
| `bfs-ioq ~/code/android -name TestSidecarCompat.java -quit` | 0.441 ± 0.285 | 0.084 | 0.846 | 1.00 |


## Search strategies

### dfs

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main -S dfs ~/code/linux -false` | 72.8 ± 13.5 | 60.3 | 101.8 | 1.34 ± 0.37 |
| `bfs-ioq~2 -S dfs ~/code/linux -false` | 100.7 ± 44.5 | 67.6 | 262.4 | 1.85 ± 0.90 |
| `bfs-ioq~1 -S dfs ~/code/linux -false` | 90.7 ± 11.6 | 70.5 | 112.0 | 1.67 ± 0.41 |
| `bfs-ioq -S dfs ~/code/linux -false` | 54.5 ± 11.4 | 37.0 | 75.5 | 1.00 |

### ids

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main -S ids ~/code/linux -false` | 358.5 ± 18.9 | 343.1 | 404.0 | 1.40 ± 0.08 |
| `bfs-ioq~2 -S ids ~/code/linux -false` | 612.4 ± 19.1 | 588.8 | 647.3 | 2.38 ± 0.09 |
| `bfs-ioq~1 -S ids ~/code/linux -false` | 440.1 ± 15.2 | 425.6 | 469.8 | 1.71 ± 0.07 |
| `bfs-ioq -S ids ~/code/linux -false` | 257.0 ± 6.0 | 247.5 | 264.4 | 1.00 |

### eds

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main -S eds ~/code/linux -false` | 139.8 ± 10.5 | 117.6 | 158.6 | 1.41 ± 0.22 |
| `bfs-ioq~2 -S eds ~/code/linux -false` | 319.5 ± 17.2 | 285.1 | 350.0 | 3.22 ± 0.47 |
| `bfs-ioq~1 -S eds ~/code/linux -false` | 159.0 ± 12.9 | 140.5 | 186.7 | 1.60 ± 0.25 |
| `bfs-ioq -S eds ~/code/linux -false` | 99.1 ± 13.3 | 79.3 | 135.5 | 1.00 |


## Cold cache

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/linux -false` | 96.1 ± 9.3 | 86.0 | 110.8 | 1.39 ± 0.24 |
| `bfs-ioq~2 ~/code/linux -false` | 243.6 ± 40.2 | 197.2 | 337.4 | 3.51 ± 0.76 |
| `bfs-ioq~1 ~/code/linux -false` | 99.9 ± 11.9 | 85.4 | 121.6 | 1.44 ± 0.27 |
| `bfs-ioq ~/code/linux -false` | 69.4 ± 9.8 | 54.1 | 80.2 | 1.00 |

</details>