### PR TITLE
I/O queue scalability

### DIFF
--- a/src/bfstd.c
+++ b/src/bfstd.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: 0BSD
 
 #include "bfstd.h"
+#include "bit.h"
 #include "config.h"
 #include "diag.h"
 #include "xregex.h"
@@ -140,6 +141,19 @@ char *xgetdelim(FILE *file, char delim) {
 		}
 		return NULL;
 	}
+}
+
+void *xmemalign(size_t align, size_t size) {
+	bfs_assert(has_single_bit(align));
+	bfs_assert((size & (align - 1)) == 0);
+
+#if __APPLE__
+	void *ptr = NULL;
+	errno = posix_memalign(&ptr, align, size);
+	return ptr;
+#else
+	return aligned_alloc(align, size);
+#endif
 }
 
 /** Compile and execute a regular expression for xrpmatch(). */

--- a/src/bfstd.h
+++ b/src/bfstd.h
@@ -106,6 +106,18 @@ char *xgetdelim(FILE *file, char delim);
 // #include <stdlib.h>
 
 /**
+ * Portable version of aligned_alloc()/posix_memalign().
+ *
+ * @param align
+ *         The allocation's alignment.
+ * @param size
+ *         The allocation's size.
+ * @return
+ *         The allocation, or NULL on failure.
+ */
+void *xmemalign(size_t align, size_t size);
+
+/**
  * Process a yes/no prompt.
  *
  * @return 1 for yes, 0 for no, and -1 for unknown.

--- a/src/config.h
+++ b/src/config.h
@@ -191,6 +191,29 @@ static inline size_t flex_sizeof_impl(size_t align, size_t min, size_t offset, s
 	return ret;
 }
 
+/**
+ * False sharing/destructive interference/largest cache line size.
+ */
+#ifdef __GCC_DESTRUCTIVE_SIZE
+#  define FALSE_SHARING_SIZE __GCC_DESTRUCTIVE_SIZE
+#else
+#  define FALSE_SHARING_SIZE 64
+#endif
+
+/**
+ * True sharing/constructive interference/smallest cache line size.
+ */
+#ifdef __GCC_CONSTRUCTIVE_SIZE
+#  define TRUE_SHARING_SIZE __GCC_CONSTRUCTIVE_SIZE
+#else
+#  define TRUE_SHARING_SIZE 64
+#endif
+
+/**
+ * Alignment specifier that avoids false sharing.
+ */
+#define cache_align alignas(FALSE_SHARING_SIZE)
+
 // Wrappers for attributes
 
 /**

--- a/src/ioq.c
+++ b/src/ioq.c
@@ -2,14 +2,17 @@
 // SPDX-License-Identifier: 0BSD
 
 #include "ioq.h"
+#include "atomic.h"
+#include "bfstd.h"
+#include "bit.h"
+#include "config.h"
+#include "diag.h"
 #include "dir.h"
-#include "list.h"
 #include "lock.h"
 #include "sanity.h"
 #include <assert.h>
 #include <errno.h>
 #include <pthread.h>
-#include <stdbool.h>
 #include <stdlib.h>
 
 /**
@@ -28,101 +31,224 @@ struct ioq_req {
 /**
  * An I/O queue command.
  */
-struct ioq_cmd {
-	union {
-		struct ioq_req req;
-		struct ioq_res res;
-	};
-
-	struct ioq_cmd *next;
+union ioq_cmd {
+	struct ioq_req req;
+	struct ioq_res res;
 };
+
+/**
+ * A monitor for an I/O queue slot.
+ */
+struct ioq_monitor {
+	cache_align pthread_mutex_t mutex;
+	pthread_cond_t full;
+	pthread_cond_t empty;
+};
+
+/** Initialize an ioq_monitor. */
+static int ioq_monitor_init(struct ioq_monitor *monitor) {
+	if (mutex_init(&monitor->mutex, NULL) != 0) {
+		goto fail;
+	}
+
+	if (cond_init(&monitor->full, NULL) != 0) {
+		goto fail_mutex;
+	}
+
+	if (cond_init(&monitor->empty, NULL) != 0) {
+		goto fail_full;
+	}
+
+	return 0;
+
+fail_full:
+	cond_destroy(&monitor->full);
+fail_mutex:
+	mutex_destroy(&monitor->mutex);
+fail:
+	return -1;
+}
+
+/** Destroy an ioq_monitor. */
+static void ioq_monitor_destroy(struct ioq_monitor *monitor) {
+	cond_destroy(&monitor->empty);
+	cond_destroy(&monitor->full);
+	mutex_destroy(&monitor->mutex);
+}
+
+/**
+ * A slot in an I/O queue.
+ */
+struct ioq_slot {
+	struct ioq_monitor *monitor;
+	union ioq_cmd *cmd;
+};
+
+/** Initialize an ioq_slot. */
+static void ioq_slot_init(struct ioq_slot *slot, struct ioq_monitor *monitor) {
+	slot->monitor = monitor;
+	slot->cmd = NULL;
+}
+
+/** Push a command into a slot. */
+static void ioq_slot_push(struct ioq_slot *slot, union ioq_cmd *cmd) {
+	struct ioq_monitor *monitor = slot->monitor;
+
+	mutex_lock(&monitor->mutex);
+	while (slot->cmd) {
+		cond_wait(&monitor->empty, &monitor->mutex);
+	}
+	slot->cmd = cmd;
+	mutex_unlock(&monitor->mutex);
+
+	cond_broadcast(&monitor->full);
+}
+
+/** Pop a command from a slot. */
+static union ioq_cmd *ioq_slot_pop(struct ioq_slot *slot) {
+	struct ioq_monitor *monitor = slot->monitor;
+
+	mutex_lock(&monitor->mutex);
+	while (!slot->cmd) {
+		cond_wait(&monitor->full, &monitor->mutex);
+	}
+	union ioq_cmd *ret = slot->cmd;
+	slot->cmd = NULL;
+	mutex_unlock(&monitor->mutex);
+
+	cond_broadcast(&monitor->empty);
+
+	return ret;
+}
+
+/** Pop a command from a slot, if one exists. */
+static union ioq_cmd *ioq_slot_trypop(struct ioq_slot *slot) {
+	struct ioq_monitor *monitor = slot->monitor;
+
+	if (!mutex_trylock(&monitor->mutex)) {
+		return NULL;
+	}
+
+	union ioq_cmd *ret = slot->cmd;
+	slot->cmd = NULL;
+
+	mutex_unlock(&monitor->mutex);
+
+	if (ret) {
+		cond_broadcast(&monitor->empty);
+	}
+	return ret;
+}
 
 /**
  * An MPMC queue of I/O commands.
  */
 struct ioqq {
-	pthread_mutex_t mutex;
-	pthread_cond_t cond;
+	/** Circular buffer index mask. */
+	size_t mask;
 
-	bool stop;
+	/** Number of monitors. */
+	size_t nmonitors;
+	/** Array of monitors used by the slots. */
+	struct ioq_monitor *monitors;
 
-	struct ioq_cmd *head;
-	struct ioq_cmd **tail;
+	/** Index of next writer. */
+	cache_align atomic size_t head;
+	/** Index of next reader. */
+	cache_align atomic size_t tail;
+
+	/** The circular buffer itself. */
+	cache_align struct ioq_slot slots[];
 };
 
-static struct ioqq *ioqq_create(void) {
-	struct ioqq *ioqq = malloc(sizeof(*ioqq));
-	if (!ioqq) {
-		goto fail;
+// If we assign slots sequentially, threads will likely be operating on
+// consecutive slots.  If these slots are in the same cache line, that will
+// result in false sharing.  We can mitigate this by assigning slots with a
+// stride larger than a cache line e.g. 0, 9, 18, ..., 1, 10, 19, ...
+// As long as the stride is relatively prime to circular buffer length, we'll
+// still use every available slot.  Since the length is a power of two, that
+// means the stride must be odd.
+
+#define IOQ_STRIDE ((FALSE_SHARING_SIZE / sizeof(struct ioq_slot)) | 1)
+bfs_static_assert(IOQ_STRIDE % 2 == 1);
+
+/** Destroy an I/O command queue. */
+static void ioqq_destroy(struct ioqq *ioqq) {
+	for (size_t i = 0; i < ioqq->nmonitors; ++i) {
+		ioq_monitor_destroy(&ioqq->monitors[i]);
 	}
-
-	if (mutex_init(&ioqq->mutex, NULL) != 0) {
-		goto fail_free;
-	}
-
-	if (cond_init(&ioqq->cond, NULL) != 0) {
-		goto fail_mutex;
-	}
-
-	ioqq->stop = false;
-	SLIST_INIT(ioqq);
-	return ioqq;
-
-fail_mutex:
-	mutex_destroy(&ioqq->mutex);
-fail_free:
+	free(ioqq->monitors);
 	free(ioqq);
-fail:
-	return NULL;
 }
 
-/** Push a command onto the queue. */
-static void ioqq_push(struct ioqq *ioqq, struct ioq_cmd *cmd) {
-	mutex_lock(&ioqq->mutex);
-	SLIST_APPEND(ioqq, cmd);
-	mutex_unlock(&ioqq->mutex);
-	cond_signal(&ioqq->cond);
-}
+/** Create an I/O command queue. */
+static struct ioqq *ioqq_create(size_t size) {
+	// Circular buffer size must be a power of two
+	size = bit_ceil(size);
 
-/** Pop a command from a queue. */
-static struct ioq_cmd *ioqq_pop(struct ioqq *ioqq) {
-	mutex_lock(&ioqq->mutex);
-
-	while (!ioqq->stop && !ioqq->head) {
-		cond_wait(&ioqq->cond, &ioqq->mutex);
-	}
-
-	struct ioq_cmd *cmd = SLIST_POP(ioqq);
-	mutex_unlock(&ioqq->mutex);
-	return cmd;
-}
-
-/** Pop a command from a queue without blocking. */
-static struct ioq_cmd *ioqq_trypop(struct ioqq *ioqq) {
-	if (!mutex_trylock(&ioqq->mutex)) {
+	struct ioqq *ioqq = xmemalign(alignof(struct ioqq), flex_sizeof(struct ioqq, slots, size));
+	if (!ioqq) {
 		return NULL;
 	}
 
-	struct ioq_cmd *cmd = SLIST_POP(ioqq);
-	mutex_unlock(&ioqq->mutex);
+	// Use a pool of monitors
+	size_t nmonitors = size < 64 ? size : 64;
+	ioqq->nmonitors = 0;
+	ioqq->monitors = xmemalign(alignof(struct ioq_monitor), nmonitors * sizeof(struct ioq_monitor));
+	if (!ioqq->monitors) {
+		ioqq_destroy(ioqq);
+		return NULL;
+	}
+
+	for (size_t i = 0; i < nmonitors; ++i) {
+		if (ioq_monitor_init(&ioqq->monitors[i]) != 0) {
+			ioqq_destroy(ioqq);
+			return NULL;
+		}
+		++ioqq->nmonitors;
+	}
+
+	ioqq->mask = size - 1;
+
+	atomic_init(&ioqq->head, 0);
+	atomic_init(&ioqq->tail, 0);
+
+	for (size_t i = 0; i < size; ++i) {
+		ioq_slot_init(&ioqq->slots[i], &ioqq->monitors[i % nmonitors]);
+	}
+
+	return ioqq;
+}
+
+/** Push a command onto the queue. */
+static void ioqq_push(struct ioqq *ioqq, union ioq_cmd *cmd) {
+	size_t i = fetch_add(&ioqq->head, IOQ_STRIDE, relaxed);
+	ioq_slot_push(&ioqq->slots[i & ioqq->mask], cmd);
+}
+
+/** Pop a command from a queue. */
+static union ioq_cmd *ioqq_pop(struct ioqq *ioqq) {
+	size_t i = fetch_add(&ioqq->tail, IOQ_STRIDE, relaxed);
+	return ioq_slot_pop(&ioqq->slots[i & ioqq->mask]);
+}
+
+/** Pop a command from a queue if one is available. */
+static union ioq_cmd *ioqq_trypop(struct ioqq *ioqq) {
+	size_t i = load(&ioqq->tail, relaxed);
+	union ioq_cmd *cmd = ioq_slot_trypop(&ioqq->slots[i & ioqq->mask]);
+	if (cmd) {
+#ifdef NDEBUG
+		store(&ioqq->tail, i + IOQ_STRIDE, relaxed);
+#else
+		size_t j = fetch_add(&ioqq->tail, IOQ_STRIDE, relaxed);
+		bfs_assert(j == i, "ioqq_trypop() only supports a single consumer");
+#endif
+	}
 	return cmd;
 }
 
-/** Stop a queue, waking up any waiters. */
-static void ioqq_stop(struct ioqq *ioqq) {
-	mutex_lock(&ioqq->mutex);
-	ioqq->stop = true;
-	mutex_unlock(&ioqq->mutex);
-	cond_broadcast(&ioqq->cond);
-}
-
-static void ioqq_destroy(struct ioqq *ioqq) {
-	if (ioqq) {
-		cond_destroy(&ioqq->cond);
-		mutex_destroy(&ioqq->mutex);
-		free(ioqq);
-	}
-}
+/** Sentinel stop command. */
+static union ioq_cmd IOQ_STOP;
 
 struct ioq {
 	/** The depth of the queue. */
@@ -146,8 +272,8 @@ static void *ioq_work(void *ptr) {
 	struct ioq *ioq = ptr;
 
 	while (true) {
-		struct ioq_cmd *cmd = ioqq_pop(ioq->pending);
-		if (!cmd) {
+		union ioq_cmd *cmd = ioqq_pop(ioq->pending);
+		if (cmd == &IOQ_STOP) {
 			break;
 		}
 
@@ -176,16 +302,17 @@ struct ioq *ioq_create(size_t depth, size_t threads) {
 
 	ioq->depth = depth;
 	ioq->size = 0;
+
 	ioq->pending = NULL;
 	ioq->ready = NULL;
 	ioq->nthreads = 0;
 
-	ioq->pending = ioqq_create();
+	ioq->pending = ioqq_create(depth);
 	if (!ioq->pending) {
 		goto fail;
 	}
 
-	ioq->ready = ioqq_create();
+	ioq->ready = ioqq_create(depth);
 	if (!ioq->ready) {
 		goto fail;
 	}
@@ -218,7 +345,7 @@ int ioq_opendir(struct ioq *ioq, int dfd, const char *path, void *ptr) {
 		return -1;
 	}
 
-	struct ioq_cmd *cmd = malloc(sizeof(*cmd));
+	union ioq_cmd *cmd = malloc(sizeof(*cmd));
 	if (!cmd) {
 		return -1;
 	}
@@ -228,8 +355,8 @@ int ioq_opendir(struct ioq *ioq, int dfd, const char *path, void *ptr) {
 	req->path = path;
 	req->ptr = ptr;
 
-	++ioq->size;
 	ioqq_push(ioq->pending, cmd);
+	++ioq->size;
 	return 0;
 }
 
@@ -238,11 +365,7 @@ struct ioq_res *ioq_pop(struct ioq *ioq) {
 		return NULL;
 	}
 
-	struct ioq_cmd *cmd = ioqq_pop(ioq->ready);
-	if (!cmd) {
-		return NULL;
-	}
-
+	union ioq_cmd *cmd = ioqq_pop(ioq->ready);
 	--ioq->size;
 	return &cmd->res;
 }
@@ -252,7 +375,7 @@ struct ioq_res *ioq_trypop(struct ioq *ioq) {
 		return NULL;
 	}
 
-	struct ioq_cmd *cmd = ioqq_trypop(ioq->ready);
+	union ioq_cmd *cmd = ioqq_trypop(ioq->ready);
 	if (!cmd) {
 		return NULL;
 	}
@@ -262,7 +385,7 @@ struct ioq_res *ioq_trypop(struct ioq *ioq) {
 }
 
 void ioq_free(struct ioq *ioq, struct ioq_res *res) {
-	struct ioq_cmd *cmd = (struct ioq_cmd *)res;
+	union ioq_cmd *cmd = (union ioq_cmd *)res;
 	free(cmd);
 }
 
@@ -271,8 +394,8 @@ void ioq_destroy(struct ioq *ioq) {
 		return;
 	}
 
-	if (ioq->pending) {
-		ioqq_stop(ioq->pending);
+	for (size_t i = 0; i < ioq->nthreads; ++i) {
+		ioqq_push(ioq->pending, &IOQ_STOP);
 	}
 
 	for (size_t i = 0; i < ioq->nthreads; ++i) {


### PR DESCRIPTION
<details>
<summary>Full benchmark results</summary>

## Complete traversal

### Small tree

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/bfs/history -false` | 2.9 ± 0.2 | 2.6 | 4.1 | 1.00 |
| `bfs-ioq-scale ~/code/bfs/history -false` | 3.0 ± 0.2 | 2.6 | 3.9 | 1.03 ± 0.08 |

### Medium tree

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/linux -false` | 45.1 ± 1.7 | 41.3 | 48.8 | 1.10 ± 0.06 |
| `bfs-ioq-scale ~/code/linux -false` | 40.9 ± 1.4 | 38.6 | 45.1 | 1.00 |

### Large tree

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/android -false` | 801.1 ± 24.7 | 751.5 | 845.3 | 1.20 ± 0.05 |
| `bfs-ioq-scale ~/code/android -false` | 666.7 ± 16.6 | 646.9 | 706.2 | 1.00 |


## Early termination

### Shallow file

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/android -name ConstClassBenchmark.java -quit` | 137.3 ± 191.9 | 19.2 | 713.6 | 1.00 |
| `bfs-ioq-scale ~/code/android -name ConstClassBenchmark.java -quit` | 168.6 ± 164.0 | 18.2 | 543.7 | 1.23 ± 2.09 |

### Medium file

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/android -name DominatorsComputation.java -quit` | 82.1 ± 131.6 | 39.7 | 627.5 | 1.03 ± 2.58 |
| `bfs-ioq-scale ~/code/android -name DominatorsComputation.java -quit` | 79.5 ± 151.9 | 31.6 | 690.0 | 1.00 |

### Deep file

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/android -name TestSidecarCompat.java -quit` | 425.1 ± 292.3 | 57.1 | 680.3 | 2.45 ± 3.70 |
| `bfs-ioq-scale ~/code/android -name TestSidecarCompat.java -quit` | 173.5 ± 233.0 | 36.2 | 824.3 | 1.00 |


## Search strategies

### dfs

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main -S dfs ~/code/linux -false` | 43.8 ± 1.5 | 39.3 | 47.1 | 1.16 ± 0.07 |
| `bfs-ioq-scale -S dfs ~/code/linux -false` | 37.8 ± 1.8 | 35.2 | 44.9 | 1.00 |

### ids

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main -S ids ~/code/linux -false` | 253.8 ± 4.5 | 248.9 | 263.1 | 1.09 ± 0.03 |
| `bfs-ioq-scale -S ids ~/code/linux -false` | 232.4 ± 5.3 | 226.3 | 246.3 | 1.00 |

### eds

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main -S eds ~/code/linux -false` | 87.1 ± 2.2 | 83.9 | 94.3 | 1.09 ± 0.04 |
| `bfs-ioq-scale -S eds ~/code/linux -false` | 79.7 ± 2.2 | 75.8 | 85.1 | 1.00 |


## Cold cache

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/linux -false` | 55.0 ± 4.6 | 48.5 | 62.7 | 1.05 ± 0.10 |
| `bfs-ioq-scale ~/code/linux -false` | 52.3 ± 2.3 | 49.1 | 56.5 | 1.00 |

</details>