### PR TITLE
Arena allocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,4 +85,4 @@ jobs:
         run: |
           spurion=$(tailscale ip -6 spurion)
           rsync -rl --delete . "[$spurion]:bfs"
-          ssh "$spurion" 'gmake -C bfs -j$(sysctl -n hw.ncpu) distcheck'
+          ssh "$spurion" 'gmake -C bfs -j$(sysctl -n hw.ncpu) distcheck CC=clang16'

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ all: bfs tests
 $(BIN)/%:
 	@$(MKDIR) $(@D)
 	+$(CC) $(ALL_LDFLAGS) $^ $(ALL_LDLIBS) -o $@
-ifeq ($(OS) $(TSAN),FreeBSD tsan)
+ifeq ($(OS) $(SANITIZE),FreeBSD y)
 	elfctl -e +noaslr $@
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,7 @@ $(OBJ)/FLAGS: $(OBJ)/FLAGS.new
 
 # All object files except the entry point
 LIBBFS := \
+    $(OBJ)/src/alloc.o \
     $(OBJ)/src/bar.o \
     $(OBJ)/src/bfstd.o \
     $(OBJ)/src/bftw.o \
@@ -246,7 +247,7 @@ LIBBFS := \
 $(BIN)/bfs: $(OBJ)/src/main.o $(LIBBFS)
 
 # Standalone unit tests
-UNITS := bfstd bit trie xtimegm
+UNITS := alloc bfstd bit trie xtimegm
 UNIT_TESTS := $(UNITS:%=$(BIN)/tests/%)
 UNIT_CHECKS := $(UNITS:%=check-%)
 

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -4,6 +4,7 @@
 #include "alloc.h"
 #include "bit.h"
 #include "diag.h"
+#include "sanity.h"
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
@@ -47,4 +48,114 @@ void *zalloc(size_t align, size_t size) {
 		memset(ret, 0, size);
 	}
 	return ret;
+}
+
+/**
+ * An arena allocator chunk.
+ */
+union chunk {
+	/**
+	 * Free chunks are stored in a singly linked list.  The pointer to the
+	 * next chunk is represented by an offset from the chunk immediately
+	 * after this one in memory, so that zalloc() correctly initializes a
+	 * linked list of chunks (except for the last one).
+	 */
+	uintptr_t next;
+
+	// char object[];
+};
+
+/** Decode the next chunk. */
+static union chunk *chunk_next(const struct arena *arena, const union chunk *chunk) {
+	uintptr_t base = (uintptr_t)chunk + arena->size;
+	return (union chunk *)(base + chunk->next);
+}
+
+/** Encode the next chunk. */
+static void chunk_set_next(const struct arena *arena, union chunk *chunk, union chunk *next) {
+	uintptr_t base = (uintptr_t)chunk + arena->size;
+	chunk->next = (uintptr_t)next - base;
+}
+
+void arena_init(struct arena *arena, size_t align, size_t size) {
+	bfs_assert(has_single_bit(align));
+	bfs_assert((size & (align - 1)) == 0);
+
+	if (align < alignof(union chunk)) {
+		align = alignof(union chunk);
+	}
+	if (size < sizeof(union chunk)) {
+		size = sizeof(union chunk);
+	}
+	bfs_assert((size & (align - 1)) == 0);
+
+	arena->chunks = NULL;
+	arena->nslabs = 0;
+	arena->slabs = NULL;
+	arena->align = align;
+	arena->size = size;
+}
+
+/** Allocate a new slab. */
+static int slab_alloc(struct arena *arena) {
+	void **slabs = realloc(arena->slabs, sizeof_array(void *, arena->nslabs + 1));
+	if (!slabs) {
+		return -1;
+	}
+	arena->slabs = slabs;
+
+	// Make the initial allocation size ~4K
+	size_t size = 4096;
+	if (size < arena->size) {
+		size = arena->size;
+	}
+	// Trim off the excess
+	size -= size % arena->size;
+	// Double the size for every slab
+	size <<= arena->nslabs;
+
+	// Allocate the slab
+	void *slab = zalloc(arena->align, size);
+	if (!slab) {
+		return -1;
+	}
+
+	// Fix the last chunk->next offset
+	void *last = (char *)slab + size - arena->size;
+	chunk_set_next(arena, last, arena->chunks);
+
+	// We can rely on zero-initialized slabs, but others shouldn't
+	sanitize_uninit(slab, size);
+
+	arena->chunks = arena->slabs[arena->nslabs++] = slab;
+	return 0;
+}
+
+void *arena_alloc(struct arena *arena) {
+	if (!arena->chunks && slab_alloc(arena) != 0) {
+		return NULL;
+	}
+
+	union chunk *chunk = arena->chunks;
+	sanitize_alloc(chunk, arena->size);
+
+	sanitize_init(chunk);
+	arena->chunks = chunk_next(arena, chunk);
+	sanitize_uninit(chunk, arena->size);
+
+	return chunk;
+}
+
+void arena_free(struct arena *arena, void *ptr) {
+	union chunk *chunk = ptr;
+	chunk_set_next(arena, chunk, arena->chunks);
+	arena->chunks = chunk;
+	sanitize_free(chunk, arena->size);
+}
+
+void arena_destroy(struct arena *arena) {
+	for (size_t i = 0; i < arena->nslabs; ++i) {
+		free(arena->slabs[i]);
+	}
+	sanitize_uninit(arena);
 }

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -1,0 +1,50 @@
+// Copyright © Tavian Barnes <tavianator@tavianator.com>
+// SPDX-License-Identifier: 0BSD
+
+#include "alloc.h"
+#include "bit.h"
+#include "diag.h"
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+/** Portable aligned_alloc()/posix_memalign(). */
+static void *xmemalign(size_t align, size_t size) {
+	bfs_assert(has_single_bit(align));
+	bfs_assert(align >= sizeof(void *));
+	bfs_assert((size & (align - 1)) == 0);
+
+#if __APPLE__
+	void *ptr = NULL;
+	errno = posix_memalign(&ptr, align, size);
+	return ptr;
+#else
+	return aligned_alloc(align, size);
+#endif
+}
+
+void *alloc(size_t align, size_t size) {
+	bfs_assert(has_single_bit(align));
+	bfs_assert((size & (align - 1)) == 0);
+
+	if (align <= alignof(max_align_t)) {
+		return malloc(size);
+	} else {
+		return xmemalign(align, size);
+	}
+}
+
+void *zalloc(size_t align, size_t size) {
+	bfs_assert(has_single_bit(align));
+	bfs_assert((size & (align - 1)) == 0);
+
+	if (align <= alignof(max_align_t)) {
+		return calloc(1, size);
+	}
+
+	void *ret = xmemalign(align, size);
+	if (ret) {
+		memset(ret, 0, size);
+	}
+	return ret;
+}

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -157,5 +157,123 @@ void arena_destroy(struct arena *arena) {
 	for (size_t i = 0; i < arena->nslabs; ++i) {
 		free(arena->slabs[i]);
 	}
+	free(arena->slabs);
 	sanitize_uninit(arena);
+}
+
+void varena_init(struct varena *varena, size_t align, size_t min, size_t offset, size_t size) {
+	varena->align = align;
+	varena->offset = offset;
+	varena->size = size;
+	varena->narenas = 0;
+	varena->arenas = NULL;
+
+	// The smallest size class is at least as many as fit in the smallest
+	// aligned allocation size
+	size_t min_count = (flex_size(align, min, offset, size, 1) - offset + size - 1) / size;
+	varena->shift = bit_width(min_count - 1);
+}
+
+/** Get the size class for the given array length. */
+static size_t varena_size_class(struct varena *varena, size_t count) {
+	// Since powers of two are common array lengths, make them the
+	// (inclusive) upper bound for each size class
+	return bit_width((count - !!count) >> varena->shift);
+}
+
+/** Get the exact size of a flexible struct. */
+static size_t varena_exact_size(const struct varena *varena, size_t count) {
+	return flex_size(varena->align, 0, varena->offset, varena->size, count);
+}
+
+/** Get the arena for the given array length. */
+static struct arena *varena_get(struct varena *varena, size_t count) {
+	size_t i = varena_size_class(varena, count);
+
+	if (i >= varena->narenas) {
+		size_t narenas = i + 1;
+		struct arena *arenas = realloc(varena->arenas, sizeof_array(struct arena, narenas));
+		if (!arenas) {
+			return NULL;
+		}
+
+		for (size_t j = varena->narenas; j < narenas; ++j) {
+			size_t shift = j + varena->shift;
+			size_t size = varena_exact_size(varena, (size_t)1 << shift);
+			arena_init(&arenas[j], varena->align, size);
+		}
+
+		varena->narenas = narenas;
+		varena->arenas = arenas;
+	}
+
+	return &varena->arenas[i];
+}
+
+void *varena_alloc(struct varena *varena, size_t count) {
+	struct arena *arena = varena_get(varena, count);
+	if (!arena) {
+		return NULL;
+	}
+
+	void *ret = arena_alloc(arena);
+	if (!ret) {
+		return NULL;
+	}
+
+	// Tell the sanitizers the exact size of the allocated struct
+	sanitize_free(ret, arena->size);
+	sanitize_alloc(ret, varena_exact_size(varena, count));
+
+	return ret;
+}
+
+void *varena_realloc(struct varena *varena, void *ptr, size_t old_count, size_t new_count) {
+	struct arena *new_arena = varena_get(varena, new_count);
+	struct arena *old_arena = varena_get(varena, old_count);
+	if (!new_arena) {
+		return NULL;
+	}
+
+	size_t new_exact_size = varena_exact_size(varena, new_count);
+	size_t old_exact_size = varena_exact_size(varena, old_count);
+
+	if (new_arena == old_arena) {
+		if (new_count < old_count) {
+			sanitize_free((char *)ptr + new_exact_size, old_exact_size - new_exact_size);
+		} else if (new_count > old_count) {
+			sanitize_alloc((char *)ptr + old_exact_size, new_exact_size - old_exact_size);
+		}
+		return ptr;
+	}
+
+	void *ret = arena_alloc(new_arena);
+	if (!ret) {
+		return NULL;
+	}
+
+	size_t old_size = old_arena->size;
+	sanitize_alloc((char *)ptr + old_exact_size, old_size - old_exact_size);
+
+	size_t new_size = new_arena->size;
+	size_t min_size = new_size < old_size ? new_size : old_size;
+	memcpy(ret, ptr, min_size);
+
+	arena_free(old_arena, ptr);
+	sanitize_free((char *)ret + new_exact_size, new_size - new_exact_size);
+
+	return ret;
+}
+
+void varena_free(struct varena *varena, void *ptr, size_t count) {
+	struct arena *arena = varena_get(varena, count);
+	arena_free(arena, ptr);
+}
+
+void varena_destroy(struct varena *varena) {
+	for (size_t i = 0; i < varena->narenas; ++i) {
+		arena_destroy(&varena->arenas[i]);
+	}
+	free(varena->arenas);
+	sanitize_uninit(varena);
 }

--- a/src/alloc.h
+++ b/src/alloc.h
@@ -146,4 +146,48 @@ void *zalloc(size_t align, size_t size);
 #define ZALLOC_FLEX(type, member, count) \
 	(type *)zalloc(alignof(type), sizeof_flex(type, member, count))
 
+/**
+ * An arena allocator for fixed-size types.
+ *
+ * Arena allocators are intentionally not thread safe.
+ */
+struct arena {
+	/** The list of free chunks. */
+	void *chunks;
+	/** The number of allocated slabs. */
+	size_t nslabs;
+	/** The array of slabs. */
+	void **slabs;
+	/** Chunk alignment. */
+	size_t align;
+	/** Chunk size. */
+	size_t size;
+};
+
+/**
+ * Initialize an arena for chunks of the given size and alignment.
+ */
+void arena_init(struct arena *arena, size_t align, size_t size);
+
+/**
+ * Initialize an arena for the given type.
+ */
+#define ARENA_INIT(arena, type) \
+	arena_init((arena), alignof(type), sizeof(type))
+
+/**
+ * Allocate an object out of the arena.
+ */
+void *arena_alloc(struct arena *arena);
+
+/**
+ * Free an object from the arena.
+ */
+void arena_free(struct arena *arena, void *ptr);
+
+/**
+ * Destroy an arena, freeing all allocations.
+ */
+void arena_destroy(struct arena *arena);
+
 #endif // BFS_ALLOC_H

--- a/src/alloc.h
+++ b/src/alloc.h
@@ -1,0 +1,149 @@
+// Copyright © Tavian Barnes <tavianator@tavianator.com>
+// SPDX-License-Identifier: 0BSD
+
+/**
+ * Memory allocation.
+ */
+
+#ifndef BFS_ALLOC_H
+#define BFS_ALLOC_H
+
+#include "config.h"
+#include <stddef.h>
+
+/** Round down to a multiple of an alignment. */
+static inline size_t align_floor(size_t align, size_t size) {
+	return size & ~(align - 1);
+}
+
+/** Round up to a multiple of an alignment. */
+static inline size_t align_ceil(size_t align, size_t size) {
+	return align_floor(align, size + align - 1);
+}
+
+/**
+ * Saturating array size.
+ *
+ * @param align
+ *         Array element alignment.
+ * @param size
+ *         Array element size.
+ * @param count
+ *         Array element count.
+ * @return
+ *         size * count, saturating to the maximum aligned value on overflow.
+ */
+static inline size_t array_size(size_t align, size_t size, size_t count) {
+	size_t ret = size * count;
+	return ret / size == count ? ret : ~(align - 1);
+}
+
+/** Saturating array sizeof. */
+#define sizeof_array(type, count) \
+	array_size(alignof(type), sizeof(type), count)
+
+/** Size of a struct/union field. */
+#define sizeof_member(type, member) \
+	sizeof(((type *)NULL)->member)
+
+/**
+ * Saturating flexible struct size.
+ *
+ * @param align
+ *         Struct alignment.
+ * @param min
+ *         Minimum struct size.
+ * @param offset
+ *         Flexible array member offset.
+ * @param size
+ *         Flexible array element size.
+ * @param count
+ *         Flexible array element count.
+ * @return
+ *         The size of the struct with count flexible array elements.  Saturates
+ *         to the maximum aligned value on overflow.
+ */
+static inline size_t flex_size(size_t align, size_t min, size_t offset, size_t size, size_t count) {
+	size_t ret = size * count;
+	size_t overflow = ret / size != count;
+
+	size_t extra = offset + align - 1;
+	ret += extra;
+	overflow |= ret < extra;
+	ret |= -overflow;
+	ret = align_floor(align, ret);
+
+	// Make sure flex_sizeof(type, member, 0) >= sizeof(type), even if the
+	// type has more padding than necessary for alignment
+	if (min > align_ceil(align, offset)) {
+		ret = ret < min ? min : ret;
+	}
+
+	return ret;
+}
+
+/**
+ * Computes the size of a flexible struct.
+ *
+ * @param type
+ *         The type of the struct containing the flexible array.
+ * @param member
+ *         The name of the flexible array member.
+ * @param count
+ *         The length of the flexible array.
+ * @return
+ *         The size of the struct with count flexible array elements.  Saturates
+ *         to the maximum aligned value on overflow.
+ */
+#define sizeof_flex(type, member, count) \
+	flex_size(alignof(type), sizeof(type), offsetof(type, member), sizeof_member(type, member[0]), count)
+
+/**
+ * General memory allocator.
+ *
+ * @param align
+ *         The required alignment.
+ * @param size
+ *         The size of the allocation.
+ * @return
+ *         The allocated memory, or NULL on failure.
+ */
+void *alloc(size_t align, size_t size);
+
+/**
+ * Zero-initialized memory allocator.
+ *
+ * @param align
+ *         The required alignment.
+ * @param size
+ *         The size of the allocation.
+ * @return
+ *         The allocated memory, or NULL on failure.
+ */
+void *zalloc(size_t align, size_t size);
+
+/** Allocate memory for the given type. */
+#define ALLOC(type) \
+	(type *)alloc(alignof(type), sizeof(type))
+
+/** Allocate zeroed memory for the given type. */
+#define ZALLOC(type) \
+	(type *)zalloc(alignof(type), sizeof(type))
+
+/** Allocate memory for an array. */
+#define ALLOC_ARRAY(type, count) \
+	(type *)alloc(alignof(type), sizeof_array(type, count));
+
+/** Allocate zeroed memory for an array. */
+#define ZALLOC_ARRAY(type, count) \
+	(type *)zalloc(alignof(type), sizeof_array(type, count));
+
+/** Allocate memory for a flexible struct. */
+#define ALLOC_FLEX(type, member, count) \
+	(type *)alloc(alignof(type), sizeof_flex(type, member, count))
+
+/** Allocate zeroed memory for a flexible struct. */
+#define ZALLOC_FLEX(type, member, count) \
+	(type *)zalloc(alignof(type), sizeof_flex(type, member, count))
+
+#endif // BFS_ALLOC_H

--- a/src/bfstd.c
+++ b/src/bfstd.c
@@ -143,19 +143,6 @@ char *xgetdelim(FILE *file, char delim) {
 	}
 }
 
-void *xmemalign(size_t align, size_t size) {
-	bfs_assert(has_single_bit(align));
-	bfs_assert((size & (align - 1)) == 0);
-
-#if __APPLE__
-	void *ptr = NULL;
-	errno = posix_memalign(&ptr, align, size);
-	return ptr;
-#else
-	return aligned_alloc(align, size);
-#endif
-}
-
 /** Compile and execute a regular expression for xrpmatch(). */
 static int xrpregex(nl_item item, const char *response) {
 	const char *pattern = nl_langinfo(item);

--- a/src/bfstd.c
+++ b/src/bfstd.c
@@ -243,6 +243,14 @@ static char type_char(mode_t mode) {
 	return '?';
 }
 
+void *xmemdup(const void *src, size_t size) {
+	void *ret = malloc(size);
+	if (ret) {
+		memcpy(ret, src, size);
+	}
+	return ret;
+}
+
 void xstrmode(mode_t mode, char str[11]) {
 	strcpy(str, "----------");
 

--- a/src/bfstd.h
+++ b/src/bfstd.h
@@ -106,18 +106,6 @@ char *xgetdelim(FILE *file, char delim);
 // #include <stdlib.h>
 
 /**
- * Portable version of aligned_alloc()/posix_memalign().
- *
- * @param align
- *         The allocation's alignment.
- * @param size
- *         The allocation's size.
- * @return
- *         The allocation, or NULL on failure.
- */
-void *xmemalign(size_t align, size_t size);
-
-/**
  * Process a yes/no prompt.
  *
  * @return 1 for yes, 0 for no, and -1 for unknown.

--- a/src/bfstd.h
+++ b/src/bfstd.h
@@ -127,6 +127,18 @@ int ynprompt(void);
 // #include <string.h>
 
 /**
+ * Allocate a copy of a region of memory.
+ *
+ * @param src
+ *         The memory region to copy.
+ * @param size
+ *         The size of the memory region.
+ * @return
+ *         A copy of the region, allocated with malloc(), or NULL on failure.
+ */
+void *xmemdup(const void *src, size_t size);
+
+/**
  * Format a mode like ls -l (e.g. -rw-r--r--).
  *
  * @param mode

--- a/src/bftw.c
+++ b/src/bftw.c
@@ -17,6 +17,7 @@
  */
 
 #include "bftw.h"
+#include "alloc.h"
 #include "bfstd.h"
 #include "config.h"
 #include "diag.h"
@@ -241,9 +242,7 @@ static void bftw_cache_destroy(struct bftw_cache *cache) {
 /** Create a new bftw_file. */
 static struct bftw_file *bftw_file_new(struct bftw_file *parent, const char *name) {
 	size_t namelen = strlen(name);
-	size_t size = flex_sizeof(struct bftw_file, name, namelen + 1);
-
-	struct bftw_file *file = malloc(size);
+	struct bftw_file *file = ALLOC_FLEX(struct bftw_file, name, namelen + 1);
 	if (!file) {
 		return NULL;
 	}

--- a/src/color.c
+++ b/src/color.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: 0BSD
 
 #include "color.h"
+#include "alloc.h"
 #include "bfstd.h"
 #include "bftw.h"
 #include "config.h"
@@ -404,7 +405,7 @@ static void parse_gnu_ls_colors(struct colors *colors, const char *ls_colors) {
 }
 
 struct colors *parse_colors(void) {
-	struct colors *colors = malloc(sizeof(struct colors));
+	struct colors *colors = ALLOC(struct colors);
 	if (!colors) {
 		return NULL;
 	}
@@ -497,7 +498,7 @@ void free_colors(struct colors *colors) {
 }
 
 CFILE *cfwrap(FILE *file, const struct colors *colors, bool close) {
-	CFILE *cfile = malloc(sizeof(*cfile));
+	CFILE *cfile = ALLOC(CFILE);
 	if (!cfile) {
 		return NULL;
 	}

--- a/src/config.h
+++ b/src/config.h
@@ -142,56 +142,6 @@
 #define countof(array) (sizeof(array) / sizeof(0[array]))
 
 /**
- * Round down to a multiple of an alignment.
- */
-static inline size_t align_floor(size_t align, size_t size) {
-	return size & ~(align - 1);
-}
-
-/**
- * Round up to a multiple of an alignment.
- */
-static inline size_t align_ceil(size_t align, size_t size) {
-	return align_floor(align, size + align - 1);
-}
-
-/**
- * Computes the size of a struct containing a flexible array member of the given
- * length.
- *
- * @param type
- *         The type of the struct containing the flexible array.
- * @param member
- *         The name of the flexible array member.
- * @param count
- *         The length of the flexible array.
- */
-#define flex_sizeof(type, member, count) \
-	flex_sizeof_impl(alignof(type), sizeof(type), offsetof(type, member), sizeof(((type *)NULL)->member[0]), count)
-
-static inline size_t flex_sizeof_impl(size_t align, size_t min, size_t offset, size_t size, size_t count) {
-	size_t ret = size * count;
-	size_t overflow = ret / size != count;
-
-	ret += offset;
-	overflow |= ret < offset;
-
-	size_t mask = align - 1;
-	ret += mask;
-	overflow |= ret < mask;
-	ret |= -overflow;
-	ret &= ~mask;
-
-	// Make sure flex_sizeof(type, member, 0) >= sizeof(type), even if the
-	// type has more padding than necessary for alignment
-	if (min > align_ceil(align, offset) && ret < min) {
-		ret = min;
-	}
-
-	return ret;
-}
-
-/**
  * False sharing/destructive interference/largest cache line size.
  */
 #ifdef __GCC_DESTRUCTIVE_SIZE

--- a/src/ctx.c
+++ b/src/ctx.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: 0BSD
 
 #include "ctx.h"
+#include "alloc.h"
 #include "color.h"
 #include "darray.h"
 #include "diag.h"
@@ -42,43 +43,17 @@ const char *debug_flag_name(enum debug_flags flag) {
 }
 
 struct bfs_ctx *bfs_ctx_new(void) {
-	struct bfs_ctx *ctx = malloc(sizeof(*ctx));
+	struct bfs_ctx *ctx = ZALLOC(struct bfs_ctx);
 	if (!ctx) {
 		return NULL;
 	}
 
-	ctx->argv = NULL;
-	ctx->paths = NULL;
-	ctx->expr = NULL;
-	ctx->exclude = NULL;
-
-	ctx->mindepth = 0;
 	ctx->maxdepth = INT_MAX;
 	ctx->flags = BFTW_RECOVER;
 	ctx->strategy = BFTW_BFS;
-	ctx->threads = 0;
 	ctx->optlevel = 3;
-	ctx->debug = 0;
-	ctx->ignore_races = false;
-	ctx->posixly_correct = false;
-	ctx->status = false;
-	ctx->unique = false;
-	ctx->warn = false;
-	ctx->xargs_safe = false;
-
-	ctx->colors = NULL;
-	ctx->colors_error = 0;
-	ctx->cout = NULL;
-	ctx->cerr = NULL;
-
-	ctx->users = NULL;
-	ctx->groups = NULL;
-
-	ctx->mtab = NULL;
-	ctx->mtab_error = 0;
 
 	trie_init(&ctx->files);
-	ctx->nfiles = 0;
 
 	struct rlimit rl;
 	if (getrlimit(RLIMIT_NOFILE, &rl) != 0) {
@@ -155,7 +130,7 @@ CFILE *bfs_ctx_dedup(struct bfs_ctx *ctx, CFILE *cfile, const char *path) {
 		return ctx_file->cfile;
 	}
 
-	leaf->value = ctx_file = malloc(sizeof(*ctx_file));
+	leaf->value = ctx_file = ALLOC(struct bfs_ctx_file);
 	if (!ctx_file) {
 		trie_remove(&ctx->files, leaf);
 		return NULL;

--- a/src/dir.h
+++ b/src/dir.h
@@ -8,6 +8,7 @@
 #ifndef BFS_DIR_H
 #define BFS_DIR_H
 
+#include "alloc.h"
 #include "config.h"
 #include <sys/types.h>
 
@@ -62,17 +63,35 @@ struct bfs_dirent {
 };
 
 /**
+ * Allocate space for a directory.
+ *
+ * @return
+ *         An allocated, unopen directory, or NULL on failure.
+ */
+struct bfs_dir *bfs_allocdir(void);
+
+/**
+ * Initialize an arena for directories.
+ *
+ * @param arena
+ *         The arena to initialize.
+ */
+void bfs_dir_arena(struct arena *arena);
+
+/**
  * Open a directory.
  *
+ * @param dir
+ *         The allocated directory.
  * @param at_fd
  *         The base directory for path resolution.
  * @param at_path
  *         The path of the directory to open, relative to at_fd.  Pass NULL to
  *         open at_fd itself.
  * @return
- *         The opened directory, or NULL on failure.
+ *         0 on success, or -1 on failure.
  */
-struct bfs_dir *bfs_opendir(int at_fd, const char *at_path);
+int bfs_opendir(struct bfs_dir *dir, int at_fd, const char *at_path);
 
 /**
  * Get the file descriptor for a directory.
@@ -110,7 +129,7 @@ int bfs_readdir(struct bfs_dir *dir, struct bfs_dirent *de);
 int bfs_closedir(struct bfs_dir *dir);
 
 /**
- * Free a directory, keeping an open file descriptor to it.
+ * Extract the file descriptor from an open directory.
  *
  * @param dir
  *         The directory to free.
@@ -122,6 +141,6 @@ int bfs_closedir(struct bfs_dir *dir);
  *         On success, a file descriptor for the directory is returned.  On
  *         failure, -1 is returned, and the directory remains open.
  */
-int bfs_freedir(struct bfs_dir *dir, bool same_fd);
+int bfs_fdclosedir(struct bfs_dir *dir, bool same_fd);
 
 #endif // BFS_DIR_H

--- a/src/dstring.c
+++ b/src/dstring.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: 0BSD
 
 #include "dstring.h"
+#include "alloc.h"
 #include "diag.h"
 #include <stdarg.h>
 #include <stdio.h>
@@ -24,7 +25,7 @@ static struct dstring *dstrheader(const char *dstr) {
 
 /** Get the correct size for a dstring with the given capacity. */
 static size_t dstrsize(size_t capacity) {
-	return flex_sizeof(struct dstring, data, capacity + 1);
+	return sizeof_flex(struct dstring, data, capacity + 1);
 }
 
 /** Allocate a dstring with the given contents. */

--- a/src/ioq.h
+++ b/src/ioq.h
@@ -45,6 +45,8 @@ struct ioq *ioq_create(size_t depth, size_t nthreads);
  *
  * @param ioq
  *         The I/O queue.
+ * @param dir
+ *         The allocated directory.
  * @param dfd
  *         The base file descriptor.
  * @param path
@@ -54,7 +56,7 @@ struct ioq *ioq_create(size_t depth, size_t nthreads);
  * @return
  *         0 on success, or -1 on failure.
  */
-int ioq_opendir(struct ioq *ioq, int dfd, const char *path, void *ptr);
+int ioq_opendir(struct ioq *ioq, struct bfs_dir *dir, int dfd, const char *path, void *ptr);
 
 /**
  * Pop a response from the queue.

--- a/src/ioq.h
+++ b/src/ioq.h
@@ -33,12 +33,12 @@ struct ioq_res {
  *
  * @param depth
  *         The maximum depth of the queue.
- * @param threads
+ * @param nthreads
  *         The maximum number of background threads.
  * @return
  *         The new I/O queue, or NULL on failure.
  */
-struct ioq *ioq_create(size_t depth, size_t threads);
+struct ioq *ioq_create(size_t depth, size_t nthreads);
 
 /**
  * Asynchronous bfs_opendir().

--- a/src/main.c
+++ b/src/main.c
@@ -20,6 +20,7 @@
  *     - bftw.[ch]     (an extended version of nftw(3))
  *
  * - Utilities:
+ *     - alloc.[ch]    (memory allocation)
  *     - atomic.h      (atomic operations)
  *     - bar.[ch]      (a terminal status bar)
  *     - bit.h         (bit manipulation)

--- a/src/mtab.c
+++ b/src/mtab.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: 0BSD
 
 #include "mtab.h"
+#include "alloc.h"
 #include "bfstd.h"
 #include "config.h"
 #include "darray.h"
@@ -87,15 +88,13 @@ fail:
 }
 
 struct bfs_mtab *bfs_mtab_parse(void) {
-	struct bfs_mtab *mtab = malloc(sizeof(*mtab));
+	struct bfs_mtab *mtab = ZALLOC(struct bfs_mtab);
 	if (!mtab) {
 		return NULL;
 	}
 
-	mtab->entries = NULL;
 	trie_init(&mtab->names);
 	trie_init(&mtab->types);
-	mtab->types_filled = false;
 
 	int error = 0;
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -9,6 +9,7 @@
  */
 
 #include "parse.h"
+#include "alloc.h"
 #include "bfstd.h"
 #include "bftw.h"
 #include "color.h"
@@ -55,39 +56,16 @@ static char *fake_print_arg = "-print";
 static char *fake_true_arg = "-true";
 
 struct bfs_expr *bfs_expr_new(bfs_eval_fn *eval_fn, size_t argc, char **argv) {
-	struct bfs_expr *expr = malloc(sizeof(*expr));
+	struct bfs_expr *expr = ZALLOC(struct bfs_expr);
 	if (!expr) {
-		perror("malloc()");
+		perror("zalloc()");
 		return NULL;
 	}
 
 	expr->eval_fn = eval_fn;
 	expr->argc = argc;
 	expr->argv = argv;
-	expr->persistent_fds = 0;
-	expr->ephemeral_fds = 0;
-	expr->pure = false;
-	expr->always_true = false;
-	expr->always_false = false;
-	expr->cost = 0.0;
 	expr->probability = 0.5;
-	expr->evaluations = 0;
-	expr->successes = 0;
-	expr->elapsed.tv_sec = 0;
-	expr->elapsed.tv_nsec = 0;
-
-	// Prevent bfs_expr_free() from freeing uninitialized pointers on error paths
-	if (bfs_expr_is_parent(expr)) {
-		expr->lhs = NULL;
-		expr->rhs = NULL;
-	} else if (eval_fn == eval_exec) {
-		expr->exec = NULL;
-	} else if (eval_fn == eval_fprintf) {
-		expr->printf = NULL;
-	} else if (eval_fn == eval_regex) {
-		expr->regex = NULL;
-	}
-
 	return expr;
 }
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -3666,13 +3666,10 @@ struct bfs_ctx *bfs_parse_cmdline(int argc, char *argv[]) {
 	}
 
 	ctx->argc = argc;
-	ctx->argv = malloc((argc + 1)*sizeof(*ctx->argv));
+	ctx->argv = xmemdup(argv, sizeof_array(char *, argc + 1));
 	if (!ctx->argv) {
-		perror("malloc()");
+		perror("xmemdup()");
 		goto fail;
-	}
-	for (int i = 0; i <= argc; ++i) {
-		ctx->argv[i] = argv[i];
 	}
 
 	enum use_color use_color = COLOR_AUTO;

--- a/src/pwcache.c
+++ b/src/pwcache.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: 0BSD
 
 #include "pwcache.h"
+#include "alloc.h"
 #include "config.h"
 #include "darray.h"
 #include "trie.h"
@@ -71,7 +72,7 @@ struct bfs_users {
 };
 
 struct bfs_users *bfs_users_new(void) {
-	struct bfs_users *users = malloc(sizeof(*users));
+	struct bfs_users *users = ALLOC(struct bfs_users);
 	if (!users) {
 		return NULL;
 	}
@@ -144,7 +145,7 @@ struct bfs_groups {
 };
 
 struct bfs_groups *bfs_groups_new(void) {
-	struct bfs_groups *groups = malloc(sizeof(*groups));
+	struct bfs_groups *groups = ALLOC(struct bfs_groups);
 	if (!groups) {
 		return NULL;
 	}

--- a/src/sanity.h
+++ b/src/sanity.h
@@ -73,9 +73,14 @@
 #define sanitize_uninit(...) SANITIZE_CALL(__msan_allocated_memory, __VA_ARGS__)
 
 #else
-#  define sanitize_init(...) ((void)0)
-#  define sanitize_uninit(...) ((void)0)
+#  define sanitize_init(...) SANITIZE_CALL(sanitize_ignore, __VA_ARGS__)
+#  define sanitize_uninit(...) SANITIZE_CALL(sanitize_ignore, __VA_ARGS__)
 #endif
+
+/**
+ * Squelch unused variable warnings when not sanitizing.
+ */
+#define sanitize_ignore(ptr, size) ((void)(ptr), (void)(size))
 
 /**
  * Initialize a variable, unless sanitizers would detect uninitialized uses.

--- a/src/trie.c
+++ b/src/trie.c
@@ -82,6 +82,7 @@
  */
 
 #include "trie.h"
+#include "alloc.h"
 #include "bit.h"
 #include "config.h"
 #include "diag.h"
@@ -317,7 +318,7 @@ struct trie_leaf *trie_find_prefix(const struct trie *trie, const char *key) {
 
 /** Create a new leaf, holding a copy of the given key. */
 static struct trie_leaf *trie_leaf_alloc(struct trie *trie, const void *key, size_t length) {
-	struct trie_leaf *leaf = malloc(flex_sizeof(struct trie_leaf, key, length));
+	struct trie_leaf *leaf = ALLOC_FLEX(struct trie_leaf, key, length);
 	if (!leaf) {
 		return NULL;
 	}
@@ -339,12 +340,10 @@ static void trie_leaf_free(struct trie *trie, struct trie_leaf *leaf) {
 
 /** Compute the size of a trie node with a certain number of children. */
 static size_t trie_node_size(unsigned int size) {
-	// Empty nodes aren't supported
-	bfs_assert(size > 0);
 	// Node size must be a power of two
 	bfs_assert(has_single_bit(size));
 
-	return flex_sizeof(struct trie_node, children, size);
+	return sizeof_flex(struct trie_node, children, size);
 }
 
 #if ENDIAN_NATIVE == ENDIAN_LITTLE

--- a/src/trie.h
+++ b/src/trie.h
@@ -5,6 +5,7 @@
 #define BFS_TRIE_H
 
 #include "config.h"
+#include "alloc.h"
 #include <stddef.h>
 #include <stdint.h>
 
@@ -30,6 +31,10 @@ struct trie {
 	uintptr_t root;
 	/** Linked list of leaves. */
 	struct trie_leaf *head, *tail;
+	/** Node allocator. */
+	struct varena nodes;
+	/** Leaf allocator. */
+	struct varena leaves;
 };
 
 /**

--- a/src/xregex.c
+++ b/src/xregex.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: 0BSD
 
 #include "xregex.h"
+#include "alloc.h"
 #include "config.h"
 #include "diag.h"
 #include "sanity.h"
@@ -115,7 +116,7 @@ static int bfs_onig_initialize(OnigEncoding *enc) {
 #endif
 
 int bfs_regcomp(struct bfs_regex **preg, const char *pattern, enum bfs_regex_type type, enum bfs_regcomp_flags flags) {
-	struct bfs_regex *regex = *preg = malloc(sizeof(*regex));
+	struct bfs_regex *regex = *preg = ALLOC(struct bfs_regex);
 	if (!regex) {
 		return -1;
 	}

--- a/src/xspawn.c
+++ b/src/xspawn.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: 0BSD
 
 #include "xspawn.h"
+#include "alloc.h"
 #include "bfstd.h"
 #include "config.h"
 #include "list.h"
@@ -62,7 +63,7 @@ int bfs_spawn_setflags(struct bfs_spawn *ctx, enum bfs_spawn_flags flags) {
 
 /** Add a spawn action to the chain. */
 static struct bfs_spawn_action *bfs_spawn_add(struct bfs_spawn *ctx, enum bfs_spawn_op op) {
-	struct bfs_spawn_action *action = malloc(sizeof(*action));
+	struct bfs_spawn_action *action = ALLOC(struct bfs_spawn_action);
 	if (!action) {
 		return NULL;
 	}

--- a/tests/alloc.c
+++ b/tests/alloc.c
@@ -1,0 +1,24 @@
+// Copyright © Tavian Barnes <tavianator@tavianator.com>
+// SPDX-License-Identifier: 0BSD
+
+#include "../src/alloc.h"
+#include "../src/diag.h"
+#include <stdlib.h>
+
+int main(void) {
+	// Check sizeof_flex()
+	struct flexible {
+		alignas(64) int foo;
+		int bar[];
+	};
+	bfs_verify(sizeof_flex(struct flexible, bar, 0) >= sizeof(struct flexible));
+	bfs_verify(sizeof_flex(struct flexible, bar, 16) % alignof(struct flexible) == 0);
+	bfs_verify(sizeof_flex(struct flexible, bar, SIZE_MAX / sizeof(int) + 1)
+	           == align_floor(alignof(struct flexible), SIZE_MAX));
+
+	// Corner case: sizeof(type) > align_ceil(alignof(type), offsetof(type, member))
+	// Doesn't happen in typical ABIs
+	bfs_verify(flex_size(8, 16, 4, 4, 1) == 16);
+
+	return EXIT_SUCCESS;
+}

--- a/tests/bfstd.c
+++ b/tests/bfstd.c
@@ -24,17 +24,6 @@ static void check_base_dir(const char *path, const char *dir, const char *base) 
 }
 
 int main(void) {
-	// Check flex_sizeof()
-	struct flexible {
-		alignas(64) int foo;
-		int bar[];
-	};
-	bfs_verify(flex_sizeof(struct flexible, bar, 0) >= sizeof(struct flexible));
-	bfs_verify(flex_sizeof(struct flexible, bar, 16) % alignof(struct flexible) == 0);
-	bfs_verify(flex_sizeof(struct flexible, bar, SIZE_MAX / sizeof(int) + 1)
-	           == align_floor(alignof(struct flexible), SIZE_MAX));
-	bfs_verify(flex_sizeof_impl(8, 16, 4, 4, 1) == 16);
-
 	// From man 3p basename
 	check_base_dir("usr", ".", "usr");
 	check_base_dir("usr/", ".", "usr");
@@ -46,4 +35,6 @@ int main(void) {
 	check_base_dir("/usr/lib", "/usr", "lib");
 	check_base_dir("//usr//lib//", "//usr", "lib");
 	check_base_dir("/home//dwc//test", "/home//dwc", "test");
+
+	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Another casual ~17% perf boost

<details>
<summary>Full benchmark results</summary>

## Complete traversal

### Small tree

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/bfs/history -false` | 3.1 ± 0.2 | 2.6 | 4.1 | 1.06 ± 0.08 |
| `bfs-alloc ~/code/bfs/history -false` | 2.9 ± 0.1 | 2.6 | 3.4 | 1.00 |

### Medium tree

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/linux -false` | 40.8 ± 1.4 | 37.8 | 43.7 | 1.11 ± 0.05 |
| `bfs-alloc ~/code/linux -false` | 36.9 ± 1.3 | 34.8 | 40.4 | 1.00 |

### Large tree

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/android -false` | 662.1 ± 19.6 | 619.0 | 685.1 | 1.17 ± 0.05 |
| `bfs-alloc ~/code/android -false` | 563.7 ± 19.5 | 543.1 | 604.7 | 1.00 |


## Early termination

### Shallow file

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/android -name ConstClassBenchmark.java -quit` | 123.6 ± 109.6 | 17.6 | 306.6 | 3.57 ± 7.09 |
| `bfs-alloc ~/code/android -name ConstClassBenchmark.java -quit` | 34.6 ± 61.5 | 15.2 | 573.3 | 1.00 |

### Medium file

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/android -name DominatorsComputation.java -quit` | 89.6 ± 172.5 | 31.3 | 709.8 | 1.69 ± 4.35 |
| `bfs-alloc ~/code/android -name DominatorsComputation.java -quit` | 53.0 ± 90.6 | 32.9 | 599.1 | 1.00 |

### Deep file

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/android -name TestSidecarCompat.java -quit` | 166.0 ± 229.3 | 37.4 | 750.7 | 1.56 ± 2.44 |
| `bfs-alloc ~/code/android -name TestSidecarCompat.java -quit` | 106.6 ± 78.8 | 46.2 | 317.0 | 1.00 |


## Search strategies

### dfs

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main -S dfs ~/code/linux -false` | 37.0 ± 1.3 | 34.3 | 41.0 | 1.14 ± 0.06 |
| `bfs-alloc -S dfs ~/code/linux -false` | 32.3 ± 1.4 | 30.0 | 38.5 | 1.00 |

### ids

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main -S ids ~/code/linux -false` | 236.9 ± 4.0 | 228.9 | 242.6 | 1.03 ± 0.02 |
| `bfs-alloc -S ids ~/code/linux -false` | 231.0 ± 2.7 | 227.5 | 235.8 | 1.00 |

### eds

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main -S eds ~/code/linux -false` | 81.2 ± 2.2 | 77.7 | 86.1 | 1.05 ± 0.04 |
| `bfs-alloc -S eds ~/code/linux -false` | 77.4 ± 2.2 | 73.6 | 84.5 | 1.00 |


## Cold cache

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/linux -false` | 52.7 ± 3.0 | 48.6 | 58.2 | 1.08 ± 0.09 |
| `bfs-alloc ~/code/linux -false` | 48.7 ± 2.6 | 42.3 | 52.8 | 1.00 |

</details>