### PR TITLE
ioq: Implement async close() and closedir()

### DIFF
--- a/src/dir.h
+++ b/src/dir.h
@@ -13,6 +13,14 @@
 #include <sys/types.h>
 
 /**
+ * Whether the implementation uses the getdents() syscall directly, rather than
+ * libc's readdir().
+ */
+#ifndef BFS_USE_GETDENTS
+#  define BFS_USE_GETDENTS (__linux__ || __FreeBSD__)
+#endif
+
+/**
  * A directory.
  */
 struct bfs_dir;
@@ -129,18 +137,22 @@ int bfs_readdir(struct bfs_dir *dir, struct bfs_dirent *de);
 int bfs_closedir(struct bfs_dir *dir);
 
 /**
- * Extract the file descriptor from an open directory.
+ * Whether the bfs_unwrapdir() function is supported.
+ */
+#ifndef BFS_USE_UNWRAPDIR
+#  define BFS_USE_UNWRAPDIR (BFS_USE_GETDENTS || __FreeBSD__)
+#endif
+
+#if BFS_USE_UNWRAPDIR
+/**
+ * Detach the file descriptor from an open directory.
  *
  * @param dir
- *         The directory to free.
- * @param same_fd
- *         If true, require that the returned file descriptor is the same one
- *         that bfs_dirfd() would have returned.  Otherwise, it may be a new
- *         file descriptor for the same directory.
+ *         The directory to detach.
  * @return
- *         On success, a file descriptor for the directory is returned.  On
- *         failure, -1 is returned, and the directory remains open.
+ *         The file descriptor of the directory.
  */
-int bfs_fdclosedir(struct bfs_dir *dir, bool same_fd);
+int bfs_unwrapdir(struct bfs_dir *dir);
+#endif
 
 #endif // BFS_DIR_H

--- a/src/ioq.c
+++ b/src/ioq.c
@@ -355,6 +355,10 @@ fail:
 	return NULL;
 }
 
+size_t ioq_capacity(const struct ioq *ioq) {
+	return ioq->depth - ioq->size;
+}
+
 int ioq_opendir(struct ioq *ioq, struct bfs_dir *dir, int dfd, const char *path, void *ptr) {
 	if (ioq->size >= ioq->depth) {
 		return -1;
@@ -382,7 +386,6 @@ struct ioq_res *ioq_pop(struct ioq *ioq) {
 	}
 
 	union ioq_cmd *cmd = ioqq_pop(ioq->ready);
-	--ioq->size;
 	return &cmd->res;
 }
 
@@ -396,11 +399,13 @@ struct ioq_res *ioq_trypop(struct ioq *ioq) {
 		return NULL;
 	}
 
-	--ioq->size;
 	return &cmd->res;
 }
 
 void ioq_free(struct ioq *ioq, struct ioq_res *res) {
+	bfs_assert(ioq->size > 0);
+	--ioq->size;
+
 	arena_free(&ioq->cmds, (union ioq_cmd *)res);
 }
 

--- a/src/ioq.h
+++ b/src/ioq.h
@@ -41,6 +41,11 @@ struct ioq_res {
 struct ioq *ioq_create(size_t depth, size_t nthreads);
 
 /**
+ * Check the remaining capacity of a queue.
+ */
+size_t ioq_capacity(const struct ioq *ioq);
+
+/**
  * Asynchronous bfs_opendir().
  *
  * @param ioq


### PR DESCRIPTION
~~Right now this improves complete traversal but massively regresses the early termination benchmarks.~~

~~Fixed the early-termination regression, but now the perf results are kind of a mixed bag.~~

~~Re-introduced the early-termination regressions, in exchange for *huge* (**~58%**) complete traversal speedups.  Early termination seems to slow down due to bad luck with traversal order caused by https://github.com/tavianator/bfs/pull/105/commits/b1ae0f6a5bfc0bd1336d0dfa44be61da4fc289d8.  I'll try to think of a fix.~~

The early-termination regression is partially mitigated.  I consider the overall improvement important enough to merge this now.

<details>
<summary>Full benchmark results</summary>

## Complete traversal

### Small tree

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/bfs/history -false` | 3.1 ± 0.1 | 2.9 | 3.2 | 1.00 |
| `bfs-ioq-close ~/code/bfs/history -false` | 3.2 ± 0.2 | 2.9 | 3.7 | 1.03 ± 0.06 |

### Medium tree

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/linux -false` | 37.7 ± 0.7 | 35.9 | 38.6 | 1.22 ± 0.05 |
| `bfs-ioq-close ~/code/linux -false` | 31.0 ± 1.1 | 28.4 | 32.7 | 1.00 |

### Large tree

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/android -false` | 616.1 ± 23.7 | 552.3 | 636.1 | 1.48 ± 0.07 |
| `bfs-ioq-close ~/code/android -false` | 415.7 ± 10.9 | 392.4 | 426.6 | 1.00 |


## Early termination

### Shallow file

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/android -name ConstClassBenchmark.java -quit` | 51.3 ± 99.7 | 12.6 | 329.1 | 1.00 |
| `bfs-ioq-close ~/code/android -name ConstClassBenchmark.java -quit` | 62.1 ± 64.0 | 12.0 | 247.7 | 1.21 ± 2.66 |

### Medium file

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/android -name DominatorsComputation.java -quit` | 50.4 ± 96.7 | 24.8 | 461.2 | 1.00 |
| `bfs-ioq-close ~/code/android -name DominatorsComputation.java -quit` | 87.4 ± 55.6 | 21.0 | 212.9 | 1.73 ± 3.50 |

### Deep file

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/android -name TestSidecarCompat.java -quit` | 74.0 ± 24.0 | 30.1 | 120.7 | 1.00 |
| `bfs-ioq-close ~/code/android -name TestSidecarCompat.java -quit` | 365.5 ± 111.5 | 26.5 | 451.9 | 4.94 ± 2.20 |


## Printing paths

### Without colors

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/linux` | 53.6 ± 1.6 | 51.8 | 58.9 | 1.08 ± 0.06 |
| `bfs-ioq-close ~/code/linux` | 49.6 ± 2.2 | 44.9 | 56.1 | 1.00 |

### With colors

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/linux -color` | 276.3 ± 5.0 | 271.3 | 289.2 | 1.00 |
| `bfs-ioq-close ~/code/linux -color` | 276.6 ± 4.0 | 269.8 | 284.0 | 1.00 ± 0.02 |


## Search strategies

### dfs

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main -S dfs ~/code/linux -false` | 36.1 ± 0.9 | 34.6 | 38.0 | 1.00 ± 0.04 |
| `bfs-ioq-close -S dfs ~/code/linux -false` | 36.0 ± 1.0 | 35.0 | 39.2 | 1.00 |

### ids

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main -S ids ~/code/linux -false` | 243.0 ± 9.9 | 231.0 | 258.0 | 1.30 ± 0.07 |
| `bfs-ioq-close -S ids ~/code/linux -false` | 186.9 ± 5.6 | 178.5 | 200.9 | 1.00 |

### eds

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main -S eds ~/code/linux -false` | 81.3 ± 2.4 | 78.4 | 88.2 | 1.19 ± 0.07 |
| `bfs-ioq-close -S eds ~/code/linux -false` | 68.2 ± 3.5 | 63.1 | 76.1 | 1.00 |


## Cold cache

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-main ~/code/linux -false` | 44.7 ± 2.3 | 42.2 | 52.2 | 1.34 ± 0.09 |
| `bfs-ioq-close ~/code/linux -false` | 33.4 ± 1.6 | 31.2 | 36.3 | 1.00 |

</details>