### PR TITLE
CFLAGS adjustment in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ endif
 
 ifneq ($(filter release,$(MAKECMDGOALS)),)
 LOCAL_CPPFLAGS += -DNDEBUG
-CFLAGS := $(DEFAULT_CFLAGS) -O3 -flto
+CFLAGS := $(DEFAULT_CFLAGS) -O3 -flto=auto
 endif
 
 ALL_CPPFLAGS = $(LOCAL_CPPFLAGS) $(CPPFLAGS) $(EXTRA_CPPFLAGS)


### PR DESCRIPTION
-flto=auto to eliminate "using serial compilation of 3 LTRANS jobs" gcc warning
see https://stackoverflow.com/questions/72218980/gcc-v12-1-warning-about-serial-compilation
