### PR TITLE
docs: bfs uses C17

### DIFF
--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -17,7 +17,7 @@ This enables machine processing of license information based on the SPDX License
 Implementation
 --------------
 
-`bfs` is written in [C](https://en.wikipedia.org/wiki/C_(programming_language)), specifically [C11](https://en.wikipedia.org/wiki/C11_(C_standard_revision)).
+`bfs` is written in [C](https://en.wikipedia.org/wiki/C_(programming_language)), specifically [C17](https://en.wikipedia.org/wiki/C17_(C_standard_revision)).
 You can get a feel for the coding style by skimming the source code.
 [`main.c`](/src/main.c) contains an overview of the rest of source files.
 A quick summary:


### PR DESCRIPTION
Hello :wave: 

Here is a quick PR to reflect that `bfs` has been using C17 since 3.0.