### PR TITLE
ioq benchmarking and performance improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ BINS := \
     bin/tests/mksock \
     bin/tests/units \
     bin/tests/xspawnee \
-    bin/tests/xtouch
+    bin/tests/xtouch \
+    bin/bench/ioq
 
 all: ${BINS}
 .PHONY: all
@@ -214,6 +215,14 @@ ${DISTCHECKS}::
 	    && ../configure MAKE="${MAKE}" ${DISTCHECK_CONFIG_${@:distcheck-%=%}} \
 	    && ${MAKE} check TEST_FLAGS="--sudo --verbose=skipped"
 	@test "$${GITHUB_ACTIONS-}" != true || printf '::endgroup::\n'
+
+## Benchmarks (`make bench`)
+
+bench: bin/bench/ioq
+.PHONY: bench
+
+bin/bench/ioq: obj/bench/ioq.o ${LIBBFS}
+OBJS += obj/bench/ioq.o
 
 ## Automatic dependency tracking
 

--- a/bench/ioq.c
+++ b/bench/ioq.c
@@ -1,0 +1,322 @@
+// Copyright © Tavian Barnes <tavianator@tavianator.com>
+// SPDX-License-Identifier: 0BSD
+
+#include "atomic.h"
+#include "bfs.h"
+#include "bfstd.h"
+#include "diag.h"
+#include "ioq.h"
+#include "sighook.h"
+#include "xtime.h"
+
+#include <errno.h>
+#include <locale.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+/** Which clock to use for benchmarking. */
+static clockid_t clockid = CLOCK_REALTIME;
+
+/** Get a current time measurement. */
+static void gettime(struct timespec *tp) {
+	int ret = clock_gettime(clockid, tp);
+	bfs_everify(ret == 0, "clock_gettime(%d)", (int)clockid);
+}
+
+/**
+ * Time measurements.
+ */
+struct times {
+	/** The start time. */
+	struct timespec start;
+
+	/** Total requests started. */
+	size_t pushed;
+	/** Total requests finished. */
+	size_t popped;
+
+	/** Number of timed requests (latency). */
+	size_t timed_reqs;
+	/** The start time for the currently tracked request. */
+	struct timespec req_start;
+	/** Whether a timed request is currently in flight. */
+	bool timing;
+
+	/** Latency measurements. */
+	struct {
+		struct timespec min;
+		struct timespec max;
+		struct timespec sum;
+	} latency;
+};
+
+/** Initialize a timer. */
+static void times_init(struct times *times) {
+	*times = (struct times) {
+		.latency = {
+			.min = { .tv_sec = 1000 },
+		},
+	};
+	gettime(&times->start);
+}
+
+/** Start timing a single request. */
+static void start_request(struct times *times) {
+	gettime(&times->req_start);
+	times->timing = true;
+}
+
+/** Finish timing a request. */
+static void finish_request(struct times *times) {
+	struct timespec elapsed;
+	gettime(&elapsed);
+	timespec_sub(&elapsed, &times->req_start);
+
+	timespec_min(&times->latency.min, &elapsed);
+	timespec_max(&times->latency.max, &elapsed);
+	timespec_add(&times->latency.sum, &elapsed);
+
+	bfs_assert(times->timing);
+	times->timing = false;
+	++times->timed_reqs;
+}
+
+/** Add times to the totals, and reset the lap times. */
+static void times_lap(struct times *total, struct times *lap) {
+	total->pushed += lap->pushed;
+	total->popped += lap->popped;
+	total->timed_reqs += lap->timed_reqs;
+
+	timespec_min(&total->latency.min, &lap->latency.min);
+	timespec_max(&total->latency.max, &lap->latency.max);
+	timespec_add(&total->latency.sum, &lap->latency.sum);
+
+	times_init(lap);
+}
+
+/** Print some times. */
+static void times_print(const struct times *times, long seconds) {
+	struct timespec elapsed;
+	gettime(&elapsed);
+	timespec_sub(&elapsed, &times->start);
+
+	double fsec = timespec_ns(&elapsed) / 1.0e9;
+	double iops = times->popped / fsec;
+	double mean = timespec_ns(&times->latency.sum) / times->timed_reqs;
+	double min = timespec_ns(&times->latency.min);
+	double max = timespec_ns(&times->latency.max);
+
+	if (seconds > 0) {
+		printf("%9ld", seconds);
+	} else if (elapsed.tv_nsec >= 10 * 1000 * 1000) {
+		printf("%9.2f", fsec);
+	} else {
+		printf("%9.0f", fsec);
+	}
+
+	printf(" │ %'17.0f │ %'15.0f ∈ [%'6.0f .. %'7.0f]\n", iops, mean, min, max);
+	fflush(stdout);
+}
+
+/** Push an ioq request. */
+static bool push(struct ioq *ioq, enum ioq_nop_type type, struct times *lap) {
+	void *ptr = NULL;
+
+	// Track latency for a small fraction of requests
+	if (!lap->timing && (lap->pushed + 1) % 128 == 0) {
+		start_request(lap);
+		ptr = lap;
+	}
+
+	int ret = ioq_nop(ioq, type, ptr);
+	if (ret != 0) {
+		bfs_everify(errno == EAGAIN, "ioq_nop(%d)", (int)type);
+		return false;
+	}
+
+	++lap->pushed;
+	return true;
+}
+
+/** Pop an ioq request. */
+static bool pop(struct ioq *ioq, struct times *lap, bool block) {
+	struct ioq_ent *ent = ioq_pop(ioq, block);
+	if (!ent) {
+		return false;
+	}
+
+	if (ent->ptr) {
+		finish_request(lap);
+	}
+
+	ioq_free(ioq, ent);
+	++lap->popped;
+	return true;
+}
+
+/** ^C flag. */
+static atomic bool quit = false;
+
+/** ^C hook. */
+static void ctrlc(int sig, siginfo_t *info, void *arg) {
+	store(&quit, true, relaxed);
+}
+
+int main(int argc, char *argv[]) {
+	// Use CLOCK_MONOTONIC if available
+#if defined(_POSIX_MONOTONIC_CLOCK) && _POSIX_MONOTONIC_CLOCK >= 0
+	if (sysoption(MONOTONIC_CLOCK) > 0) {
+		clockid = CLOCK_MONOTONIC;
+	}
+#endif
+
+	// Enable thousands separators
+	setlocale(LC_ALL, "");
+
+	// -d: queue depth
+	long depth = 4096;
+	// -j: threads
+	long threads = 0;
+	// -t: timeout
+	double timeout = 5.0;
+	// -L|-H: ioq_nop() type
+	enum ioq_nop_type type = IOQ_NOP_LIGHT;
+
+	const char *cmd = argc > 0 ? argv[0] : "ioq";
+	int c;
+	while (c = getopt(argc, argv, ":d:j:t:LH"), c != -1) {
+		switch (c) {
+		case 'd':
+			if (xstrtol(optarg, NULL, 10, &depth) != 0) {
+				fprintf(stderr, "%s: Bad depth '%s': %s\n", cmd, optarg, errstr());
+				return EXIT_FAILURE;
+			}
+			break;
+		case 'j':
+			if (xstrtol(optarg, NULL, 10, &threads) != 0) {
+				fprintf(stderr, "%s: Bad thread count '%s': %s\n", cmd, optarg, errstr());
+				return EXIT_FAILURE;
+			}
+			break;
+		case 't':
+			if (xstrtod(optarg, NULL, &timeout) != 0) {
+				fprintf(stderr, "%s: Bad timeout '%s': %s\n", cmd, optarg, errstr());
+				return EXIT_FAILURE;
+			}
+			break;
+		case 'L':
+		 	type = IOQ_NOP_LIGHT;
+			break;
+		case 'H':
+		 	type = IOQ_NOP_HEAVY;
+			break;
+		case ':':
+			fprintf(stderr, "%s: Missing argument to -%c\n", cmd, optopt);
+			return EXIT_FAILURE;
+		case '?':
+			fprintf(stderr, "%s: Unrecognized option -%c\n", cmd, optopt);
+			return EXIT_FAILURE;
+		}
+	}
+
+	if (threads <= 0) {
+		threads = xsysconf(_SC_NPROCESSORS_ONLN);
+		if (threads > 8) {
+			threads = 8;
+		}
+	}
+	if (threads < 2) {
+		threads = 2;
+	}
+	--threads;
+
+	// Listen for ^C to print the summary
+	struct sighook *hook = sighook(SIGINT, ctrlc, NULL, SH_CONTINUE | SH_ONESHOT);
+
+	printf("I/O queue benchmark (%s)\n\n", bfs_version);
+
+	printf("[-d] depth:   %ld\n", depth);
+	printf("[-j] threads: %ld (including main)\n", threads + 1);
+	if (type == IOQ_NOP_HEAVY) {
+		printf("[-H] type:    heavy (with syscalls)\n");
+	} else {
+		printf("[-L] type:    light (no syscalls)\n");
+	}
+	printf("\n");
+
+	printf(" Time (s) │ Throughput (IO/s) │ Latency (ns/IO)\n");
+	printf("══════════╪═══════════════════╪═════════════════\n");
+	fflush(stdout);
+
+	struct ioq *ioq = ioq_create(depth, threads);
+	bfs_everify(ioq, "ioq_create(%ld, %ld)", depth, threads);
+
+	// Pre-allocate all the requests
+	while (ioq_capacity(ioq) > 0) {
+		int ret = ioq_nop(ioq, type, NULL);
+		bfs_everify(ret == 0, "ioq_nop(%d)", (int)type);
+	}
+	while (true) {
+		struct ioq_ent *ent = ioq_pop(ioq, true);
+		if (!ent) {
+			break;
+		}
+		ioq_free(ioq, ent);
+	}
+
+	struct times total, lap;
+	times_init(&total);
+	lap = total;
+
+	long seconds = 0;
+	while (!load(&quit, relaxed)) {
+		bool was_timing = lap.timing;
+
+		for (int i = 0; i < 16; ++i) {
+			bool block = ioq_capacity(ioq) == 0;
+			if (!pop(ioq, &lap, block)) {
+				break;
+			}
+		}
+
+		if (was_timing && !lap.timing) {
+			struct timespec elapsed;
+			gettime(&elapsed);
+			timespec_sub(&elapsed, &total.start);
+
+			if (elapsed.tv_sec > seconds) {
+				seconds = elapsed.tv_sec;
+				times_print(&lap, seconds);
+				times_lap(&total, &lap);
+			}
+
+			double ns = timespec_ns(&elapsed);
+			if (timeout > 0 && ns >= timeout * 1.0e9) {
+				break;
+			}
+		}
+
+		for (int i = 0; i < 8; ++i) {
+			if (!push(ioq, type, &lap)) {
+				break;
+			}
+		}
+	}
+
+	while (pop(ioq, &lap, true));
+	times_lap(&total, &lap);
+
+	if (load(&quit, relaxed)) {
+		printf("\r────^C────┼───────────────────┼─────────────────\n");
+	} else {
+		printf("──────────┼───────────────────┼─────────────────\n");
+	}
+	times_print(&total, 0);
+
+	ioq_destroy(ioq);
+	sigunhook(hook);
+	return 0;
+}

--- a/bench/ioq.c
+++ b/bench/ioq.c
@@ -304,6 +304,7 @@ int main(int argc, char *argv[]) {
 				break;
 			}
 		}
+		ioq_submit(ioq);
 	}
 
 	while (pop(ioq, &lap, true));

--- a/build/has/pthread-set-name-np.c
+++ b/build/has/pthread-set-name-np.c
@@ -1,0 +1,10 @@
+// Copyright © Tavian Barnes <tavianator@tavianator.com>
+// SPDX-License-Identifier: 0BSD
+
+#include <pthread.h>
+#include <pthread_np.h>
+
+int main(void) {
+	pthread_set_name_np(pthread_self(), "name");
+	return 0;
+}

--- a/build/has/pthread-setname-np.c
+++ b/build/has/pthread-setname-np.c
@@ -1,0 +1,8 @@
+// Copyright © Tavian Barnes <tavianator@tavianator.com>
+// SPDX-License-Identifier: 0BSD
+
+#include <pthread.h>
+
+int main(void) {
+	return pthread_setname_np(pthread_self(), "name");
+}

--- a/build/header.mk
+++ b/build/header.mk
@@ -38,6 +38,8 @@ HEADERS := \
     gen/has/posix-getdents.h \
     gen/has/posix-spawn-addfchdir-np.h \
     gen/has/posix-spawn-addfchdir.h \
+    gen/has/pthread-set-name-np.h \
+    gen/has/pthread-setname-np.h \
     gen/has/st-acmtim.h \
     gen/has/st-acmtimespec.h \
     gen/has/st-birthtim.h \

--- a/src/bfstd.h
+++ b/src/bfstd.h
@@ -179,21 +179,24 @@ int open_cterm(int flags);
 const char *xgetprogname(void);
 
 /**
+ * Wrapper for strtol() that forbids leading spaces.
+ */
+int xstrtol(const char *str, char **end, int base, long *value);
+
+/**
  * Wrapper for strtoll() that forbids leading spaces.
- *
- * @str
- *         The string to parse.
- * @end
- *         If non-NULL, will hold a pointer to the first invalid character.
- *         If NULL, the entire string must be valid.
- * @base
- *         The base for the conversion, or 0 to auto-detect.
- * @value
- *         Will hold the parsed integer value, on success.
- * @return
- *         0 on success, -1 on failure.
  */
 int xstrtoll(const char *str, char **end, int base, long long *value);
+
+/**
+ * Wrapper for strtof() that forbids leading spaces.
+ */
+int xstrtof(const char *str, char **end, float *value);
+
+/**
+ * Wrapper for strtod() that forbids leading spaces.
+ */
+int xstrtod(const char *str, char **end, double *value);
 
 /**
  * Process a yes/no prompt.

--- a/src/bftw.c
+++ b/src/bftw.c
@@ -1051,6 +1051,10 @@ static int bftw_ioq_pop(struct bftw_state *state, bool block) {
 
 		bftw_queue_attach(&state->fileq, file, true);
 		break;
+
+	default:
+		bfs_bug("Unexpected ioq op %d", (int)op);
+		break;
 	}
 
 	ioq_free(ioq, ent);

--- a/src/bftw.c
+++ b/src/bftw.c
@@ -1008,6 +1008,7 @@ static int bftw_ioq_pop(struct bftw_state *state, bool block) {
 		return -1;
 	}
 
+	ioq_submit(ioq);
 	struct ioq_ent *ent = ioq_pop(ioq, block);
 	if (!ent) {
 		return -1;
@@ -1957,6 +1958,10 @@ static void bftw_flush(struct bftw_state *state) {
 
 	bftw_queue_flush(&state->dirq);
 	bftw_ioq_opendirs(state);
+
+	if (state->ioq) {
+		ioq_submit(state->ioq);
+	}
 }
 
 /** Close the current directory. */

--- a/src/ioq.c
+++ b/src/ioq.c
@@ -260,7 +260,17 @@ static struct ioqq *ioqq_create(size_t size) {
 
 /** Get the monitor associated with a slot. */
 static struct ioq_monitor *ioq_slot_monitor(struct ioqq *ioqq, ioq_slot *slot) {
-	size_t i = slot - ioqq->slots;
+	uint32_t i = slot - ioqq->slots;
+
+	// Hash the index to de-correlate waiters
+	// https://nullprogram.com/blog/2018/07/31/
+	// https://github.com/skeeto/hash-prospector/issues/19#issuecomment-1120105785
+	i ^= i >> 16;
+	i *= UINT32_C(0x21f0aaad);
+	i ^= i >> 15;
+	i *= UINT32_C(0x735a2d97);
+	i ^= i >> 15;
+
 	return &ioqq->monitors[i & ioqq->monitor_mask];
 }
 

--- a/src/ioq.h
+++ b/src/ioq.h
@@ -22,6 +22,8 @@ struct ioq;
  * I/O queue operations.
  */
 enum ioq_op {
+	/** ioq_nop(). */
+	IOQ_NOP,
 	/** ioq_close(). */
 	IOQ_CLOSE,
 	/** ioq_opendir(). */
@@ -30,6 +32,16 @@ enum ioq_op {
 	IOQ_CLOSEDIR,
 	/** ioq_stat(). */
 	IOQ_STAT,
+};
+
+/**
+ * ioq_nop() types.
+ */
+enum ioq_nop_type {
+	/** A lightweight nop that avoids syscalls. */
+	IOQ_NOP_LIGHT,
+	/** A heavyweight nop that involves a syscall. */
+	IOQ_NOP_HEAVY,
 };
 
 /**
@@ -54,6 +66,10 @@ struct ioq_ent {
 
 	/** Operation-specific arguments. */
 	union {
+		/** ioq_nop() args. */
+		struct ioq_nop {
+			enum ioq_nop_type type;
+		} nop;
 		/** ioq_close() args. */
 		struct ioq_close {
 			int fd;
@@ -96,6 +112,20 @@ struct ioq *ioq_create(size_t depth, size_t nthreads);
  * Check the remaining capacity of a queue.
  */
 size_t ioq_capacity(const struct ioq *ioq);
+
+/**
+ * A no-op, for benchmarking.
+ *
+ * @ioq
+ *         The I/O queue.
+ * @type
+ *         The type of operation to perform.
+ * @ptr
+ *         An arbitrary pointer to associate with the request.
+ * @return
+ *         0 on success, or -1 on failure.
+ */
+int ioq_nop(struct ioq *ioq, enum ioq_nop_type type, void *ptr);
 
 /**
  * Asynchronous close().

--- a/src/ioq.h
+++ b/src/ioq.h
@@ -8,6 +8,7 @@
 #ifndef BFS_IOQ_H
 #define BFS_IOQ_H
 
+#include "bfs.h"
 #include "dir.h"
 #include "stat.h"
 
@@ -45,18 +46,11 @@ enum ioq_nop_type {
 };
 
 /**
- * The I/O queue implementation needs two tag bits in each pointer to a struct
- * ioq_ent, so we need to ensure at least 4-byte alignment.  The natural
- * alignment is enough on most architectures, but not m68k, so over-align it.
- */
-#define IOQ_ENT_ALIGN alignas(4)
-
-/**
  * An I/O queue entry.
  */
 struct ioq_ent {
 	/** The I/O operation. */
-	IOQ_ENT_ALIGN enum ioq_op op;
+	cache_align enum ioq_op op;
 
 	/** The return value (on success) or negative error code (on failure). */
 	int result;

--- a/src/ioq.h
+++ b/src/ioq.h
@@ -190,6 +190,11 @@ int ioq_closedir(struct ioq *ioq, struct bfs_dir *dir, void *ptr);
 int ioq_stat(struct ioq *ioq, int dfd, const char *path, enum bfs_stat_flags flags, struct bfs_stat *buf, void *ptr);
 
 /**
+ * Submit any buffered requests.
+ */
+void ioq_submit(struct ioq *ioq);
+
+/**
  * Pop a response from the queue.
  *
  * @ioq

--- a/src/sighook.h
+++ b/src/sighook.h
@@ -21,6 +21,8 @@ struct sighook;
 enum sigflags {
 	/** Suppress the default action for this signal. */
 	SH_CONTINUE = 1 << 0,
+	/** Only run this hook once. */
+	SH_ONESHOT = 1 << 1,
 };
 
 /**

--- a/src/thread.c
+++ b/src/thread.c
@@ -9,6 +9,10 @@
 #include <errno.h>
 #include <pthread.h>
 
+#if __has_include(<pthread_np.h>)
+#  include <pthread_np.h>
+#endif
+
 #define THREAD_FALLIBLE(expr) \
 	do { \
 		int err = expr; \
@@ -30,6 +34,14 @@
 
 int thread_create(pthread_t *thread, const pthread_attr_t *attr, thread_fn *fn, void *arg) {
 	THREAD_FALLIBLE(pthread_create(thread, attr, fn, arg));
+}
+
+void thread_setname(pthread_t thread, const char *name) {
+#if BFS_HAS_PTHREAD_SETNAME_NP
+	pthread_setname_np(thread, name);
+#elif BFS_HAS_PTHREAD_SET_NAME_NP
+	pthread_set_name_np(thread, name);
+#endif
 }
 
 void thread_join(pthread_t thread, void **ret) {

--- a/src/thread.h
+++ b/src/thread.h
@@ -22,6 +22,11 @@ typedef void *thread_fn(void *arg);
 int thread_create(pthread_t *thread, const pthread_attr_t *attr, thread_fn *fn, void *arg);
 
 /**
+ * Set the name of a thread.
+ */
+void thread_setname(pthread_t thread, const char *name);
+
+/**
  * Wrapper for pthread_join().
  */
 void thread_join(pthread_t thread, void **ret);

--- a/src/xtime.c
+++ b/src/xtime.c
@@ -354,6 +354,59 @@ error:
 	return -1;
 }
 
+/** One nanosecond. */
+static const long NS = 1000L * 1000 * 1000;
+
+void timespec_add(struct timespec *lhs, const struct timespec *rhs) {
+	lhs->tv_sec += rhs->tv_sec;
+	lhs->tv_nsec += rhs->tv_nsec;
+	if (lhs->tv_nsec >= NS) {
+		lhs->tv_nsec -= NS;
+		lhs->tv_sec += 1;
+	}
+}
+
+void timespec_sub(struct timespec *lhs, const struct timespec *rhs) {
+	lhs->tv_sec -= rhs->tv_sec;
+	lhs->tv_nsec -= rhs->tv_nsec;
+	if (lhs->tv_nsec < 0) {
+		lhs->tv_nsec += NS;
+		lhs->tv_sec -= 1;
+	}
+}
+
+int timespec_cmp(const struct timespec *lhs, const struct timespec *rhs) {
+	if (lhs->tv_sec < rhs->tv_sec) {
+		return -1;
+	} else if (lhs->tv_sec > rhs->tv_sec) {
+		return 1;
+	}
+
+	if (lhs->tv_nsec < rhs->tv_nsec) {
+		return -1;
+	} else if (lhs->tv_nsec > rhs->tv_nsec) {
+		return 1;
+	}
+
+	return 0;
+}
+
+void timespec_min(struct timespec *dest, const struct timespec *src) {
+	if (timespec_cmp(src, dest) < 0) {
+		*dest = *src;
+	}
+}
+
+void timespec_max(struct timespec *dest, const struct timespec *src) {
+	if (timespec_cmp(src, dest) > 0) {
+		*dest = *src;
+	}
+}
+
+double timespec_ns(const struct timespec *ts) {
+	return 1.0e9 * ts->tv_sec + ts->tv_nsec;
+}
+
 #if defined(_POSIX_TIMERS) && BFS_HAS_TIMER_CREATE
 #  define BFS_POSIX_TIMERS _POSIX_TIMERS
 #else

--- a/src/xtime.h
+++ b/src/xtime.h
@@ -47,6 +47,42 @@ int xtimegm(struct tm *tm, time_t *timep);
 int xgetdate(const char *str, struct timespec *result);
 
 /**
+ * Add to a timespec.
+ */
+void timespec_add(struct timespec *lhs, const struct timespec *rhs);
+
+/**
+ * Subtract from a timespec.
+ */
+void timespec_sub(struct timespec *lhs, const struct timespec *rhs);
+
+/**
+ * Compare two timespecs.
+ *
+ * @return
+ *         An integer with the sign of (*lhs - *rhs).
+ */
+int timespec_cmp(const struct timespec *lhs, const struct timespec *rhs);
+
+/**
+ * Update a minimum timespec.
+ */
+void timespec_min(struct timespec *dest, const struct timespec *src);
+
+/**
+ * Update a maximum timespec.
+ */
+void timespec_max(struct timespec *dest, const struct timespec *src);
+
+/**
+ * Convert a timespec to floating point.
+ *
+ * @return
+ *         The value in nanoseconds.
+ */
+double timespec_ns(const struct timespec *ts);
+
+/**
  * A timer.
  */
 struct timer;

--- a/tests/ioq.c
+++ b/tests/ioq.c
@@ -49,6 +49,7 @@ static void check_ioq_push_block(void) {
 		int ret = ioq_opendir(ioq, dir, AT_FDCWD, ".", 0, NULL);
 		bfs_everify(ret == 0, "ioq_opendir()");
 	}
+	ioq_submit(ioq);
 	bfs_verify(ioq_capacity(ioq) == 0);
 
 	// Now cancel the queue, pushing an additional IOQ_STOP message


### PR DESCRIPTION
<details>
<summary>Benchmark results</summary>

## Complete traversal

### linux v6.5 (86,380 files)

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop bench/corpus/linux -false` | 22.0 ± 3.0 | 18.9 | 31.3 | 1.00 |
| `bfs-main bench/corpus/linux -false` | 22.9 ± 3.8 | 19.4 | 35.0 | 1.04 ± 0.22 |

### rust 1.72.1 (192,714 files)

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop bench/corpus/rust -false` | 54.3 ± 3.0 | 50.1 | 61.0 | 1.00 |
| `bfs-main bench/corpus/rust -false` | 57.1 ± 3.8 | 52.4 | 64.5 | 1.05 ± 0.09 |

### chromium 119.0.6036.2 (2,119,292 files)

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop bench/corpus/chromium -false` | 464.9 ± 6.4 | 459.2 | 480.4 | 1.00 |
| `bfs-main bench/corpus/chromium -false` | 503.7 ± 8.7 | 489.9 | 522.8 | 1.08 ± 0.02 |

## Early termination

### chromium 119.0.6036.2 (depth 24)

#### Depth 2

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop bench/corpus/chromium -name $(shuf -n1 $FILES) -print -quit` | 9.9 ± 2.0 | 6.1 | 14.0 | 1.00 |
| `bfs-main bench/corpus/chromium -name $(shuf -n1 $FILES) -print -quit` | 10.0 ± 1.5 | 7.9 | 13.0 | 1.02 ± 0.25 |

#### Depth 4

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop bench/corpus/chromium -name $(shuf -n1 $FILES) -print -quit` | 29.7 ± 5.1 | 22.4 | 37.0 | 1.10 ± 0.38 |
| `bfs-main bench/corpus/chromium -name $(shuf -n1 $FILES) -print -quit` | 26.9 ± 8.2 | 17.8 | 42.4 | 1.00 |

#### Depth 8

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop bench/corpus/chromium -name $(shuf -n1 $FILES) -print -quit` | 176.7 ± 15.7 | 156.1 | 200.6 | 1.00 |
| `bfs-main bench/corpus/chromium -name $(shuf -n1 $FILES) -print -quit` | 208.1 ± 16.5 | 178.0 | 224.5 | 1.18 ± 0.14 |

#### Depth 16

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop bench/corpus/chromium -name $(shuf -n1 $FILES) -print -quit` | 484.9 ± 8.1 | 476.9 | 500.1 | 1.00 |
| `bfs-main bench/corpus/chromium -name $(shuf -n1 $FILES) -print -quit` | 529.4 ± 34.1 | 510.3 | 624.9 | 1.09 ± 0.07 |

## Traversal with stat()

### rust 1.72.1 (192,714 files)

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop bench/corpus/rust -size 1024G` | 402.0 ± 28.0 | 343.3 | 447.3 | 1.00 |
| `bfs-main bench/corpus/rust -size 1024G` | 428.7 ± 36.1 | 393.4 | 488.5 | 1.07 ± 0.12 |

## Printing paths

### Without colors

#### linux v6.5

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop bench/corpus/linux` | 45.8 ± 3.6 | 40.0 | 53.5 | 1.00 |
| `bfs-main bench/corpus/linux` | 46.0 ± 4.2 | 39.7 | 53.6 | 1.00 ± 0.12 |

### With colors

#### linux v6.5

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop bench/corpus/linux -color` | 206.0 ± 10.6 | 182.0 | 226.0 | 1.00 |
| `bfs-main bench/corpus/linux -color` | 213.6 ± 6.8 | 201.0 | 223.1 | 1.04 ± 0.06 |

## Search strategies

### rust 1.72.1

#### `-S bfs`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop -S bfs bench/corpus/rust -false` | 91.9 ± 5.8 | 83.7 | 111.0 | 1.00 |
| `bfs-main -S bfs bench/corpus/rust -false` | 95.6 ± 3.3 | 89.0 | 102.1 | 1.04 ± 0.08 |

#### `-S dfs`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop -S dfs bench/corpus/rust -false` | 92.9 ± 5.1 | 84.9 | 102.4 | 1.00 |
| `bfs-main -S dfs bench/corpus/rust -false` | 94.3 ± 4.5 | 87.0 | 102.3 | 1.02 ± 0.07 |

#### `-S ids`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop -S ids bench/corpus/rust -false` | 912.3 ± 12.0 | 889.8 | 933.8 | 1.00 |
| `bfs-main -S ids bench/corpus/rust -false` | 945.3 ± 16.9 | 917.5 | 970.6 | 1.04 ± 0.02 |

#### `-S eds`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop -S eds bench/corpus/rust -false` | 205.6 ± 4.8 | 198.0 | 214.6 | 1.00 |
| `bfs-main -S eds bench/corpus/rust -false` | 223.4 ± 8.5 | 213.0 | 243.5 | 1.09 ± 0.05 |

## Parallelism

### rust 1.72.1

#### `-j1`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop -j1 bench/corpus/rust -false` | 187.4 ± 2.5 | 184.1 | 192.2 | 1.05 ± 0.05 |
| `bfs-main -j1 bench/corpus/rust -false` | 177.8 ± 8.9 | 169.6 | 192.2 | 1.00 |

#### `-j2`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop -j2 bench/corpus/rust -false` | 124.4 ± 5.6 | 117.4 | 136.5 | 1.00 |
| `bfs-main -j2 bench/corpus/rust -false` | 131.0 ± 5.9 | 124.5 | 147.8 | 1.05 ± 0.07 |

#### `-j3`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop -j3 bench/corpus/rust -false` | 101.6 ± 5.1 | 94.7 | 111.1 | 1.00 |
| `bfs-main -j3 bench/corpus/rust -false` | 105.5 ± 1.6 | 103.3 | 109.1 | 1.04 ± 0.05 |

#### `-j4`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop -j4 bench/corpus/rust -false` | 76.5 ± 1.7 | 73.5 | 79.9 | 1.00 |
| `bfs-main -j4 bench/corpus/rust -false` | 76.8 ± 3.1 | 68.4 | 81.8 | 1.00 ± 0.05 |

#### `-j6`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop -j6 bench/corpus/rust -false` | 60.4 ± 4.1 | 53.1 | 71.2 | 1.00 |
| `bfs-main -j6 bench/corpus/rust -false` | 60.8 ± 3.1 | 54.6 | 67.3 | 1.01 ± 0.09 |

#### `-j8`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop -j8 bench/corpus/rust -false` | 55.2 ± 3.9 | 49.3 | 64.8 | 1.00 |
| `bfs-main -j8 bench/corpus/rust -false` | 57.1 ± 3.2 | 52.3 | 64.8 | 1.04 ± 0.09 |

#### `-j12`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop -j12 bench/corpus/rust -false` | 54.8 ± 5.1 | 49.1 | 70.3 | 1.00 |
| `bfs-main -j12 bench/corpus/rust -false` | 58.5 ± 4.6 | 51.6 | 67.0 | 1.07 ± 0.13 |

#### `-j16`

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop -j16 bench/corpus/rust -false` | 57.3 ± 4.6 | 50.5 | 68.0 | 1.00 |
| `bfs-main -j16 bench/corpus/rust -false` | 68.1 ± 6.3 | 56.7 | 80.0 | 1.19 ± 0.14 |

## Process spawning

### linux v6.5

#### One file per process

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop bench/corpus/linux -maxdepth 2 -exec true -- {} \;` | 1.598 ± 0.046 | 1.530 | 1.662 | 1.00 |
| `bfs-main bench/corpus/linux -maxdepth 2 -exec true -- {} \;` | 1.628 ± 0.058 | 1.518 | 1.704 | 1.02 ± 0.05 |

#### Many files per process

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop bench/corpus/linux -exec true -- {} +` | 79.4 ± 3.7 | 72.3 | 88.2 | 1.00 |
| `bfs-main bench/corpus/linux -exec true -- {} +` | 82.9 ± 3.1 | 75.0 | 90.1 | 1.04 ± 0.06 |

#### Spawn in parent directory

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `bfs-ioq-nop bench/corpus/linux -maxdepth 3 -execdir true -- {} +` | 1.306 ± 0.019 | 1.282 | 1.334 | 1.00 |
| `bfs-main bench/corpus/linux -maxdepth 3 -execdir true -- {} +` | 1.315 ± 0.025 | 1.269 | 1.351 | 1.01 ± 0.02 |

## Details

### Versions

```console
$ bfs-ioq-nop --version | head -n1
bfs 4.0.4-29-gdb4eb23
$ bfs-main --version | head -n1
bfs 4.0.4-16-gaecdabb
```

</details>